### PR TITLE
update `Bender.yml` by adding correct `include_dirs`

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -66,11 +66,13 @@ sources:
     - core/cvxif_example/include/cvxif_instr_pkg.sv
     - core/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
     # Utility modules
-    - core/include/instr_tracer_pkg.sv
-    - common/local/util/instr_tracer_if.sv
-    - common/local/util/instr_tracer.sv
-    - common/local/util/sram.sv
-    - common/local/util/tc_sram_xilinx_wrapper.sv
+    - include_dirs: [common/local/util]
+      files:
+        - core/include/instr_tracer_pkg.sv
+        - common/local/util/instr_tracer_if.sv
+        - common/local/util/instr_tracer.sv
+        - common/local/util/sram.sv
+        - common/local/util/tc_sram_xilinx_wrapper.sv
     # Stand-alone source files
     - core/ariane.sv
     - core/cva6.sv


### PR DESCRIPTION
fixes `morty` pickeling