### PR TITLE
Update Bender.yml

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -7,44 +7,87 @@ package:
 
 # WT_DCACHE
 
-export_include_dirs:
-  - vendor/pulp-platform/common_cells/include/
-  - corev_apu/axi/include/
+dependencies:
+  register_interface: { git: "git@github.com:pulp-platform/register_interface.git", version: 0.3.3 }
+  axi: { git: "git@github.com:pulp-platform/axi.git", version: 0.37.0 }
+  axi_riscv_atomics: { git: "git@github.com:pulp-platform/axi_riscv_atomics.git", version: 0.5.0 }
+  tech_cells_generic: { git: "git@github.com:pulp-platform/tech_cells_generic.git", version: 0.2.9 }
+  riscv-dbg: { git: "git@github.com:pulp-platform/riscv-dbg", version: 0.7.0 }
+  common_cells: { git: "git@github.com:pulp-platform/common_cells", version: 1.25.0 }
 
 sources:
   - defines:
       WT_DCACHE: 1
     files:
+    - target: cv64a6_imafdc_sv39
+      files:
+      - core/include/cv64a6_imafdc_sv39_config_pkg.sv
+      - core/include/riscv_pkg.sv
+      - core/include/ariane_pkg.sv
+      - core/mmu_sv39/tlb.sv
+      - core/mmu_sv39/mmu.sv
+      - core/mmu_sv39/ptw.sv
+
+    - target: cv32a6_imac_sv0
+      files:
+      - core/include/cv32a6_imac_sv0_config_pkg.sv
+      - core/include/riscv_pkg.sv
+      - core/include/ariane_pkg.sv
+      - core/mmu_sv32/cva6_tlb_sv32.sv
+      - core/mmu_sv32/cva6_mmu_sv32.sv
+      - core/mmu_sv32/cva6_ptw_sv32.sv
+
+    - target: cv32a6_imac_sv32
+      files:
+      - core/include/cv32a6_imac_sv32_config_pkg.sv
+      - core/include/riscv_pkg.sv
+      - core/include/ariane_pkg.sv
+      - core/mmu_sv32/cva6_tlb_sv32.sv
+      - core/mmu_sv32/cva6_mmu_sv32.sv
+      - core/mmu_sv32/cva6_ptw_sv32.sv
+
+    - target: cv32a6_imafc_sv32
+      files:
+      - core/include/cv32a6_imafc_sv32_config_pkg.sv
+      - core/include/riscv_pkg.sv
+      - core/include/ariane_pkg.sv
+      - core/mmu_sv32/cva6_tlb_sv32.sv
+      - core/mmu_sv32/cva6_mmu_sv32.sv
+      - core/mmu_sv32/cva6_ptw_sv32.sv
+
+
     # Packages
-    - core/include/riscv_pkg.sv
-    - corev_apu/riscv-dbg/src/dm_pkg.sv
-    - core/include/ariane_pkg.sv
+    - core/include/ariane_rvfi_pkg.sv
     - core/include/wt_cache_pkg.sv
-    - corev_apu/axi/src/axi_pkg.sv
-    - corev_apu/register_interface/src/reg_intf.sv
-    - corev_apu/register_interface/src/reg_intf_pkg.sv
-    - core/include/axi_intf.sv
-    - corev_apu/tb/ariane_soc_pkg.sv
-    - corev_apu/tb/ariane_axi_soc_pkg.sv
+    - core/include/cvxif_pkg.sv
     - core/include/ariane_axi_pkg.sv
     - core/include/std_cache_pkg.sv
     - vendor/pulp-platform/fpnew/src/fpnew_pkg.sv
+    - core/cvxif_example/include/cvxif_instr_pkg.sv
     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
+    # Utility modules
+    - include_dirs: [common/local/util]
+      files:
+        - core/include/instr_tracer_pkg.sv
+        - common/local/util/instr_tracer_if.sv
+        - common/local/util/instr_tracer.sv
+        - common/local/util/sram.sv
+        - common/local/util/tc_sram_xilinx_wrapper.sv
     # Stand-alone source files
     - core/ariane.sv
+    - core/cva6.sv
     - core/serdiv.sv
     - core/ariane_regfile_ff.sv
     - core/amo_buffer.sv
     - core/id_stage.sv
     - core/branch_unit.sv
     - core/instr_realign.sv
+    - core/lsu_bypass.sv
     - core/load_store_unit.sv
     - core/controller.sv
     - core/issue_stage.sv
     - core/re_name.sv
     - core/csr_buffer.sv
-    - core/mmu_sv32/cva6_tlb_sv32.sv
-    - core/mmu_sv39/tlb.sv
     - core/decoder.sv
     - core/scoreboard.sv
     - core/perf_counters.sv
@@ -59,12 +102,9 @@ sources:
     - core/compressed_decoder.sv
     - core/axi_shim.sv
     - core/ex_stage.sv
-    - core/mmu_sv39/mmu.sv
-    - core/mmu_sv39/ptw.sv
     - core/mult.sv
-    - core/mmu_sv32/cva6_mmu_sv32.sv
-    - core/mmu_sv32/cva6_ptw_sv32.sv
     - core/load_unit.sv
+    - core/cvxif_fu.sv
     - core/issue_read_operands.sv
     - core/pmp/src/pmp_entry.sv
     - core/pmp/src/pmp.sv
@@ -106,143 +146,55 @@ sources:
     - core/cache_subsystem/cva6_icache_axi_wrapper.sv
     - core/cache_subsystem/std_cache_subsystem.sv
     - core/cache_subsystem/wt_dcache.sv
-    - corev_apu/clint/axi_lite_interface.sv
-    - corev_apu/clint/clint.sv
-    - corev_apu/fpga/src/axi2apb/src/axi2apb_wrap.sv
-    - corev_apu/fpga/src/axi2apb/src/axi2apb.sv
-    - corev_apu/fpga/src/axi2apb/src/axi2apb_64_32.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_w_buffer.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_b_buffer.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_slice_wrap.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_slice.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_single_slice.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_ar_buffer.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_r_buffer.sv
-    - corev_apu/fpga/src/axi_slice/src/axi_aw_buffer.sv
-    - corev_apu/fpga/src/apb_timer/apb_timer.sv
-    - corev_apu/fpga/src/apb_timer/timer.sv
-    - corev_apu/src/axi_riscv_atomics/src/axi_riscv_amos.sv
-    - corev_apu/src/axi_riscv_atomics/src/axi_riscv_atomics.sv
-    - corev_apu/src/axi_riscv_atomics/src/axi_res_tbl.sv
-    - corev_apu/src/axi_riscv_atomics/src/axi_riscv_lrsc_wrap.sv
-    - corev_apu/src/axi_riscv_atomics/src/axi_riscv_amos_alu.sv
-    - corev_apu/src/axi_riscv_atomics/src/axi_riscv_lrsc.sv
-    - corev_apu/src/axi_riscv_atomics/src/axi_riscv_atomics_wrap.sv
-    - corev_apu/axi_mem_if/src/axi2mem.sv
-    - corev_apu/rv_plic/rtl/rv_plic_target.sv
-    - corev_apu/rv_plic/rtl/rv_plic_gateway.sv
-    - corev_apu/rv_plic/rtl/plic_regmap.sv
-    - corev_apu/rv_plic/rtl/plic_top.sv
-    - corev_apu/riscv-dbg/src/dmi_cdc.sv
-    - corev_apu/riscv-dbg/src/dmi_jtag.sv
-    - corev_apu/riscv-dbg/src/dmi_jtag_tap.sv
-    - corev_apu/riscv-dbg/src/dm_csrs.sv
-    - corev_apu/riscv-dbg/src/dm_mem.sv
-    - corev_apu/riscv-dbg/src/dm_sba.sv
-    - corev_apu/riscv-dbg/src/dm_top.sv
-    - corev_apu/riscv-dbg/debug_rom/debug_rom.sv
-    - corev_apu/register_interface/src/apb_to_reg.sv
-    - corev_apu/axi/src/axi_multicut.sv
-    - vendor/pulp-platform/common_cells/src/cf_math_pkg.sv
-    - vendor/pulp-platform/common_cells/src/deprecated/generic_fifo.sv
-    - vendor/pulp-platform/common_cells/src/deprecated/pulp_sync.sv
-    - vendor/pulp-platform/common_cells/src/deprecated/find_first_one.sv
-    - vendor/pulp-platform/common_cells/src/rstgen_bypass.sv
-    - vendor/pulp-platform/common_cells/src/rstgen.sv
-    - vendor/pulp-platform/common_cells/src/stream_mux.sv
-    - vendor/pulp-platform/common_cells/src/stream_demux.sv
-    - vendor/pulp-platform/common_cells/src/stream_arbiter.sv
-    - vendor/pulp-platform/common_cells/src/stream_arbiter_flushable.sv
-    - corev_apu/axi/src/axi_cut.sv
-    - corev_apu/axi/src/axi_join.sv
-    - corev_apu/axi/src/axi_delayer.sv
-    - corev_apu/axi/src/axi_to_axi_lite.sv
-    - corev_apu/axi/src/axi_id_prepend.sv
-    - corev_apu/axi/src/axi_atop_filter.sv
-    - corev_apu/axi/src/axi_err_slv.sv
-    - corev_apu/axi/src/axi_mux.sv
-    - corev_apu/axi/src/axi_demux.sv
-    - corev_apu/axi/src/axi_xbar.sv
-    - common/local/techlib/fpga/rtl/SyncSpRamBeNx64.sv
-    - vendor/pulp-platform/common_cells/src/sync.sv
-    - vendor/pulp-platform/common_cells/src/popcount.sv
-    - vendor/pulp-platform/common_cells/src/unread.sv
-    - vendor/pulp-platform/common_cells/src/cdc_2phase.sv
-    - vendor/pulp-platform/common_cells/src/spill_register_flushable.sv
-    - vendor/pulp-platform/common_cells/src/spill_register.sv
-    - vendor/pulp-platform/common_cells/src/edge_detect.sv
-    - vendor/pulp-platform/common_cells/src/fifo_v3.sv
-    - vendor/pulp-platform/common_cells/src/deprecated/fifo_v2.sv
-    - vendor/pulp-platform/common_cells/src/deprecated/fifo_v1.sv
-    - vendor/pulp-platform/common_cells/src/lzc.sv
-    - vendor/pulp-platform/common_cells/src/rr_arb_tree.sv
-    - vendor/pulp-platform/common_cells/src/deprecated/rrarbiter.sv
-    - vendor/pulp-platform/common_cells/src/stream_delay.sv
-    - vendor/pulp-platform/common_cells/src/lfsr.sv
-    - vendor/pulp-platform/common_cells/src/lfsr_8bit.sv
-    - vendor/pulp-platform/common_cells/src/lfsr_16bit.sv
-    - vendor/pulp-platform/common_cells/src/counter.sv
-    - vendor/pulp-platform/common_cells/src/shift_reg.sv
-    - vendor/pulp-platform/common_cells/src/exp_backoff.sv
-    - vendor/pulp-platform/common_cells/src/addr_decode.sv
-    - vendor/pulp-platform/common_cells/src/stream_register.sv
-    - corev_apu/src/tech_cells_generic/src/cluster_clock_inverter.sv
-    - corev_apu/src/tech_cells_generic/src/pulp_clock_mux2.sv
-    - target: not(cv32a6)
-      files:
-      - core/include/cv64a6_imafdc_sv39_config_pkg.sv
-    - target: cv32a6
-      files:
-      - core/include/cv32a6_imac_sv0_config_pkg.sv
-    - target: test
-      files:
-      - corev_apu/tb/ariane_soc_pkg.sv
-      - corev_apu/tb/ariane_axi_soc_pkg.sv
-      - corev_apu/tb/ariane_testharness.sv
-      - corev_apu/tb/ariane_peripherals.sv
-      - corev_apu/tb/common/uart.sv
-      - corev_apu/tb/common/SimDTM.sv
-      - corev_apu/tb/common/SimJTAG.sv
-      - corev_apu/bootrom/bootrom.sv
-      - corev_apu/tb/common/mock_uart.sv
-      - common/local/util/sram.sv
-    - target: not(synthesis)
-      files:
-        - common/local/util/instr_tracer.sv
-        - common/local/util/instr_tracer_if.sv
-        - common/local/util/instr_trace_item.svh
-        - common/local/util/ex_trace_item.svh
-    - target: all(fpga, xilinx)
-      files:
-      - corev_apu/fpga/src/ariane_peripherals_xilinx.sv
-      - corev_apu/fpga/src/ariane_xilinx.sv
-      - corev_apu/fpga/src/fan_ctrl.sv
-      - corev_apu/fpga/src/bootrom/bootrom.sv
-      - corev_apu/fpga/src/ariane-ethernet/ssio_ddr_in.sv
-      - corev_apu/fpga/src/ariane-ethernet/rgmii_soc.sv
-      - corev_apu/fpga/src/ariane-ethernet/axis_gmii_rx.sv
-      - corev_apu/fpga/src/ariane-ethernet/oddr.sv
-      - corev_apu/fpga/src/ariane-ethernet/axis_gmii_tx.sv
-      - corev_apu/fpga/src/ariane-ethernet/dualmem_widen8.sv
-      - corev_apu/fpga/src/ariane-ethernet/rgmii_phy_if.sv
-      - corev_apu/fpga/src/ariane-ethernet/dualmem_widen.sv
-      - corev_apu/fpga/src/ariane-ethernet/rgmii_lfsr.sv
-      - corev_apu/fpga/src/ariane-ethernet/rgmii_core.sv
-      - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g.sv
-      - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g_rgmii.sv
-      - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g_rgmii_fifo.sv
-      - corev_apu/fpga/src/ariane-ethernet/iddr.sv
-      - corev_apu/fpga/src/ariane-ethernet/framing_top.sv
-      - corev_apu/fpga/src/apb_uart/src/apb_uart.vhd
-      - corev_apu/fpga/src/apb_uart/src/uart_transmitter.vhd
-      - corev_apu/fpga/src/apb_uart/src/uart_interrupt.vhd
-      - corev_apu/fpga/src/apb_uart/src/slib_mv_filter.vhd
-      - corev_apu/fpga/src/apb_uart/src/slib_input_filter.vhd
-      - corev_apu/fpga/src/apb_uart/src/slib_counter.vhd
-      - corev_apu/fpga/src/apb_uart/src/uart_receiver.vhd
-      - corev_apu/fpga/src/apb_uart/src/slib_input_sync.vhd
-      - corev_apu/fpga/src/apb_uart/src/slib_edge_detect.vhd
-      - corev_apu/fpga/src/apb_uart/src/slib_clock_div.vhd
-      - corev_apu/fpga/src/apb_uart/src/slib_fifo.vhd
-      - corev_apu/fpga/src/apb_uart/src/uart_baudgen.vhd
+
+    # - target: test
+    #   files:
+    #   - corev_apu/tb/ariane_soc_pkg.sv
+    #   - corev_apu/tb/ariane_axi_soc_pkg.sv
+    #   - corev_apu/tb/ariane_testharness.sv
+    #   - corev_apu/tb/ariane_peripherals.sv
+    #   - corev_apu/tb/common/uart.sv
+    #   - corev_apu/tb/common/SimDTM.sv
+    #   - corev_apu/tb/common/SimJTAG.sv
+      
+      
+    # - target: not(synthesis)
+    #   files:
+    #     - common/local/util/instr_tracer.sv
+    #     - common/local/util/instr_tracer_if.sv
+    #     - common/local/util/instr_trace_item.svh
+    #     - common/local/util/ex_trace_item.svh
+    # - target: all(fpga, xilinx)
+    #   files:
+    #   - corev_apu/fpga/src/ariane_peripherals_xilinx.sv
+    #   - corev_apu/fpga/src/ariane_xilinx.sv
+    #   - corev_apu/fpga/src/fan_ctrl.sv
+    #   - corev_apu/fpga/src/bootrom/bootrom.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/ssio_ddr_in.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_soc.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/axis_gmii_rx.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/oddr.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/axis_gmii_tx.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/dualmem_widen8.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_phy_if.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/dualmem_widen.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_lfsr.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/rgmii_core.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g_rgmii.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/eth_mac_1g_rgmii_fifo.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/iddr.sv
+    #   - corev_apu/fpga/src/ariane-ethernet/framing_top.sv
+    #   - corev_apu/fpga/src/apb_uart/src/apb_uart.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/uart_transmitter.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/uart_interrupt.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/slib_mv_filter.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/slib_input_filter.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/slib_counter.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/uart_receiver.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/slib_input_sync.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/slib_edge_detect.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/slib_clock_div.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/slib_fifo.vhd
+    #   - corev_apu/fpga/src/apb_uart/src/uart_baudgen.vhd
 


### PR DESCRIPTION
Update the Bender.yml. Exclude system components and benderize dependencies. Contains all changes to `Bender.yml` from https://github.com/pulp-platform/cva6/tree/cheshire