### PR TITLE
ariane_axi: Decrease AXI width to 48

### DIFF
--- a/core/include/ariane_axi_pkg.sv
+++ b/core/include/ariane_axi_pkg.sv
@@ -22,7 +22,7 @@ package ariane_axi;
 
     localparam IdWidth   = 4; // Recommended by AXI standard
     localparam UserWidth = ariane_pkg::AXI_USER_WIDTH;
-    localparam AddrWidth = 64;
+    localparam AddrWidth = 48;
     localparam DataWidth = 64;
     localparam StrbWidth = DataWidth / 8;
 


### PR DESCRIPTION
Decrease the AXI width to 48. From https://github.com/pulp-platform/cva6/tree/cheshire