### PR TITLE
update `Bender.yml` by using flist and `vendor` deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ src/moore.sv
 build/*
 /tmp*
 *.dasm
-/Bender.lock
 /Bender.local
 build/
 *.vcd
@@ -40,3 +39,5 @@ tb/riscv-isa-sim/
 work-*/*
 install/
 xrun_results/
+
+.bender/

--- a/Bender.lock
+++ b/Bender.lock
@@ -1,0 +1,45 @@
+packages:
+  axi:
+    revision: 9251564ed67e3e71adf46dbeba62ef4435d2524c
+    version: 0.31.1
+    source:
+      Git: https://github.com/pulp-platform/axi.git
+    dependencies:
+    - common_cells
+    - common_verification
+  common_cells:
+    revision: 4dc9413990622dcbf4b37a19f792834c800da5c7
+    version: 1.28.0
+    source:
+      Git: https://github.com/pulp-platform/common_cells
+    dependencies:
+    - common_verification
+    - tech_cells_generic
+  common_verification:
+    revision: 9c07fa860593b2caabd9b5681740c25fac04b878
+    version: 0.2.3
+    source:
+      Git: https://github.com/pulp-platform/common_verification.git
+    dependencies: []
+  fpnew:
+    revision: 8dc44406b1ccbc4487121710c1883e805f893965
+    version: 0.6.6
+    source:
+      Git: https://github.com/pulp-platform/fpnew.git
+    dependencies:
+    - common_cells
+    - fpu_div_sqrt_mvp
+  fpu_div_sqrt_mvp:
+    revision: 86e1f558b3c95e91577c41b2fc452c86b04e85ac
+    version: 1.0.4
+    source:
+      Git: https://github.com/pulp-platform/fpu_div_sqrt_mvp.git
+    dependencies:
+    - common_cells
+  tech_cells_generic:
+    revision: b2a68114302af1d8191ddf34ea0e07b471911866
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/tech_cells_generic.git
+    dependencies:
+    - common_verification

--- a/Bender.yml
+++ b/Bender.yml
@@ -200,6 +200,7 @@ sources:
           - common/local/util
         files:
           - common/local/util/tc_sram_fpga_wrapper.sv
+          - vendor/pulp-platform/fpga-support/rtl/SyncSpRamBeNx64.sv
 
       - target: not(synthesis)
         include_dirs:

--- a/Bender.yml
+++ b/Bender.yml
@@ -184,11 +184,22 @@ sources:
       - core/pmp/src/pmp_entry.sv
 
       - include_dirs:
+        - common/local/util
+        files:
+          - common/local/util/sram.sv
+
+      - target: not(all(fpga, xilinx))
+        include_dirs:
           - common/local/util
         files:
           - common/local/util/tc_sram_wrapper.sv
-          - common/local/util/sram.sv
           # - vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
+
+      - target: all(fpga, xilinx)
+        include_dirs:
+          - common/local/util
+        files:
+          - common/local/util/tc_sram_fpga_wrapper.sv
 
       - target: not(synthesis)
         include_dirs:

--- a/Bender.yml
+++ b/Bender.yml
@@ -23,23 +23,12 @@ sources:
   - defines:
       WT_DCACHE: 1
     files:
-      # included via target core/include/${TARGET_CFG}_config_pkg.sv
-      - core/include/riscv_pkg.sv
-      - core/include/ariane_dm_pkg.sv
-      - core/include/ariane_pkg.sv
-      # ariane_axi_pkg is dependent on this.
-      - vendor/pulp-platform/axi/src/axi_pkg.sv
-      - core/include/ariane_rvfi_pkg.sv
-
-      # Packages
-      - core/include/ariane_axi_pkg.sv
-      - core/include/wt_cache_pkg.sv
-      - core/include/std_cache_pkg.sv
-      - core/include/axi_intf.sv
-
       - target: cv64a6_imafdc_sv39
         files:
           - core/include/cv64a6_imafdc_sv39_config_pkg.sv
+          - core/include/riscv_pkg.sv
+          - core/include/ariane_dm_pkg.sv
+          - core/include/ariane_pkg.sv
           - core/mmu_sv39/tlb.sv
           - core/mmu_sv39/mmu.sv
           - core/mmu_sv39/ptw.sv
@@ -47,6 +36,9 @@ sources:
       - target: cv32a6_imac_sv0
         files:
           - core/include/cv32a6_imac_sv0_config_pkg.sv
+          - core/include/riscv_pkg.sv
+          - core/include/ariane_dm_pkg.sv
+          - core/include/ariane_pkg.sv
           - core/mmu_sv32/cva6_tlb_sv32.sv
           - core/mmu_sv32/cva6_mmu_sv32.sv
           - core/mmu_sv32/cva6_ptw_sv32.sv
@@ -54,6 +46,9 @@ sources:
       - target: cv32a6_imac_sv32
         files:
           - core/include/cv32a6_imac_sv32_config_pkg.sv
+          - core/include/riscv_pkg.sv
+          - core/include/ariane_dm_pkg.sv
+          - core/include/ariane_pkg.sv
           - core/mmu_sv32/cva6_tlb_sv32.sv
           - core/mmu_sv32/cva6_mmu_sv32.sv
           - core/mmu_sv32/cva6_ptw_sv32.sv
@@ -61,9 +56,23 @@ sources:
       - target: cv32a6_imafc_sv32
         files:
           - core/include/cv32a6_imafc_sv32_config_pkg.sv
+          - core/include/riscv_pkg.sv
+          - core/include/ariane_dm_pkg.sv
+          - core/include/ariane_pkg.sv
           - core/mmu_sv32/cva6_tlb_sv32.sv
           - core/mmu_sv32/cva6_mmu_sv32.sv
           - core/mmu_sv32/cva6_ptw_sv32.sv
+
+      # included via target core/include/${TARGET_CFG}_config_pkg.sv
+      # ariane_axi_pkg is dependent on this.
+      # - vendor/pulp-platform/axi/src/axi_pkg.sv
+      - core/include/ariane_rvfi_pkg.sv
+
+      # Packages
+      - core/include/ariane_axi_pkg.sv
+      - core/include/wt_cache_pkg.sv
+      - core/include/std_cache_pkg.sv
+      - core/include/axi_intf.sv
 
       # for all the below files use Flist.cva6 as baseline and also look at Makefile pd/synth
 
@@ -179,9 +188,11 @@ sources:
         files:
           - common/local/util/tc_sram_wrapper.sv
           - common/local/util/sram.sv
-          - vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
+          # - vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
 
       - target: not(synthesis)
+        include_dirs:
+          - core/include
         files:
           # Tracer (behavioral code, not RTL)
           - common/local/util/instr_tracer.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -166,6 +166,7 @@ sources:
       # Tracer (behavioral code, not RTL)
       - include_dirs:
         - common/local/util
+        - core/include
         files:
           - common/local/util/instr_tracer_if.sv
           - common/local/util/instr_tracer.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -7,157 +7,184 @@ package:
 
 # WT_DCACHE
 
-dependencies:
-  register_interface: { git: "git@github.com:pulp-platform/register_interface.git", version: 0.3.3 }
-  axi: { git: "git@github.com:pulp-platform/axi.git", version: 0.37.0 }
-  axi_riscv_atomics: { git: "git@github.com:pulp-platform/axi_riscv_atomics.git", version: 0.5.0 }
-  tech_cells_generic: { git: "git@github.com:pulp-platform/tech_cells_generic.git", version: 0.2.9 }
-  riscv-dbg: { git: "git@github.com:pulp-platform/riscv-dbg", version: 0.7.0 }
-  common_cells: { git: "git@github.com:pulp-platform/common_cells", version: 1.25.0 }
-
 sources:
   - defines:
       WT_DCACHE: 1
     files:
-    - target: cv64a6_imafdc_sv39
-      files:
-      - core/include/cv64a6_imafdc_sv39_config_pkg.sv
+      - target: cv64a6_imafdc_sv39
+        files:
+          - core/include/cv64a6_imafdc_sv39_config_pkg.sv
+          - core/mmu_sv39/tlb.sv
+          - core/mmu_sv39/mmu.sv
+          - core/mmu_sv39/ptw.sv
+
+      - target: cv32a6_imac_sv0
+        files:
+          - core/include/cv32a6_imac_sv0_config_pkg.sv
+          - core/mmu_sv32/cva6_tlb_sv32.sv
+          - core/mmu_sv32/cva6_mmu_sv32.sv
+          - core/mmu_sv32/cva6_ptw_sv32.sv
+
+      - target: cv32a6_imac_sv32
+        files:
+          - core/include/cv32a6_imac_sv32_config_pkg.sv
+          - core/mmu_sv32/cva6_tlb_sv32.sv
+          - core/mmu_sv32/cva6_mmu_sv32.sv
+          - core/mmu_sv32/cva6_ptw_sv32.sv
+
+      - target: cv32a6_imafc_sv32
+        files:
+          - core/include/cv32a6_imafc_sv32_config_pkg.sv
+          - core/mmu_sv32/cva6_tlb_sv32.sv
+          - core/mmu_sv32/cva6_mmu_sv32.sv
+          - core/mmu_sv32/cva6_ptw_sv32.sv
+
+      # for all the below files use Flist.cva6 as baseline and also look at Makefile pd/synth
+
+      # FPGA support
+      - vendor/pulp-platform/fpga-support/rtl/SyncDpRam.sv
+      - vendor/pulp-platform/fpga-support/rtl/AsyncDpRam.sv
+      - vendor/pulp-platform/fpga-support/rtl/AsyncThreePortRam.sv
+
+      # included via target core/include/${TARGET_CFG}_config_pkg.sv
       - core/include/riscv_pkg.sv
+      - core/include/ariane_dm_pkg.sv
       - core/include/ariane_pkg.sv
-      - core/mmu_sv39/tlb.sv
-      - core/mmu_sv39/mmu.sv
-      - core/mmu_sv39/ptw.sv
+      # ariane_axi_pkg is dependent on this.
+      - vendor/pulp-platform/axi/src/axi_pkg.sv
+      - core/include/ariane_rvfi_pkg.sv
 
-    - target: cv32a6_imac_sv0
-      files:
-      - core/include/cv32a6_imac_sv0_config_pkg.sv
-      - core/include/riscv_pkg.sv
-      - core/include/ariane_pkg.sv
-      - core/mmu_sv32/cva6_tlb_sv32.sv
-      - core/mmu_sv32/cva6_mmu_sv32.sv
-      - core/mmu_sv32/cva6_ptw_sv32.sv
+      # Packages
+      - core/include/ariane_axi_pkg.sv
+      - core/include/wt_cache_pkg.sv
+      - core/include/std_cache_pkg.sv
+      - core/include/axi_intf.sv
+      - core/include/instr_tracer_pkg.sv
 
-    - target: cv32a6_imac_sv32
-      files:
-      - core/include/cv32a6_imac_sv32_config_pkg.sv
-      - core/include/riscv_pkg.sv
-      - core/include/ariane_pkg.sv
-      - core/mmu_sv32/cva6_tlb_sv32.sv
-      - core/mmu_sv32/cva6_mmu_sv32.sv
-      - core/mmu_sv32/cva6_ptw_sv32.sv
+      # CVXIF
+      - core/include/cvxif_pkg.sv
+      - core/cvxif_example/include/cvxif_instr_pkg.sv
+      - core/cvxif_fu.sv
+      - core/cvxif_example/cvxif_example_coprocessor.sv
+      - core/cvxif_example/instr_decoder.sv
 
-    - target: cv32a6_imafc_sv32
-      files:
-      - core/include/cv32a6_imafc_sv32_config_pkg.sv
-      - core/include/riscv_pkg.sv
-      - core/include/ariane_pkg.sv
-      - core/mmu_sv32/cva6_tlb_sv32.sv
-      - core/mmu_sv32/cva6_mmu_sv32.sv
-      - core/mmu_sv32/cva6_ptw_sv32.sv
+      # common cells
+      - include_dirs: [vendor/pulp-platform/common_cells/include/, vendor/pulp-platform/common_cells/src/]
+        files:
+          - vendor/pulp-platform/common_cells/src/cf_math_pkg.sv
+          - vendor/pulp-platform/common_cells/src/fifo_v3.sv
+          - vendor/pulp-platform/common_cells/src/lfsr.sv
+          - vendor/pulp-platform/common_cells/src/lzc.sv
+          - vendor/pulp-platform/common_cells/src/rr_arb_tree.sv
+          - vendor/pulp-platform/common_cells/src/shift_reg.sv
+          - vendor/pulp-platform/common_cells/src/unread.sv
+          - vendor/pulp-platform/common_cells/src/popcount.sv
+          - vendor/pulp-platform/common_cells/src/exp_backoff.sv
+          # Common Cells for example coprocessor
+          - vendor/pulp-platform/common_cells/src/counter.sv
+          - vendor/pulp-platform/common_cells/src/delta_counter.sv
 
+          # Floating point unit
+          - vendor/pulp-platform/fpnew/src/fpnew_pkg.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_cast_multi.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_classifier.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_divsqrt_multi.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_fma_multi.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_fma.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_noncomp.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_opgroup_block.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_opgroup_fmt_slice.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_opgroup_multifmt_slice.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_rounding.sv
+          - vendor/pulp-platform/fpnew/src/fpnew_top.sv
+          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
+          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv
+          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv
+          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv
+          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv
+          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv
+          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv
 
-    # Packages
-    - core/include/ariane_rvfi_pkg.sv
-    - core/include/wt_cache_pkg.sv
-    - core/include/cvxif_pkg.sv
-    - core/include/ariane_axi_pkg.sv
-    - core/include/std_cache_pkg.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_pkg.sv
-    - core/cvxif_example/include/cvxif_instr_pkg.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
-    # Utility modules
-    - include_dirs: [common/local/util]
-      files:
-        - core/include/instr_tracer_pkg.sv
-        - common/local/util/instr_tracer_if.sv
-        - common/local/util/instr_tracer.sv
-        - common/local/util/sram.sv
-        - common/local/util/tc_sram_xilinx_wrapper.sv
-    # Stand-alone source files
-    - core/ariane.sv
-    - core/cva6.sv
-    - core/serdiv.sv
-    - core/ariane_regfile_ff.sv
-    - core/amo_buffer.sv
-    - core/id_stage.sv
-    - core/branch_unit.sv
-    - core/instr_realign.sv
-    - core/lsu_bypass.sv
-    - core/load_store_unit.sv
-    - core/controller.sv
-    - core/issue_stage.sv
-    - core/re_name.sv
-    - core/csr_buffer.sv
-    - core/decoder.sv
-    - core/scoreboard.sv
-    - core/perf_counters.sv
-    - core/store_unit.sv
-    - core/axi_adapter.sv
-    - core/fpu_wrap.sv
-    - core/csr_regfile.sv
-    - core/commit_stage.sv
-    - core/alu.sv
-    - core/multiplier.sv
-    - core/store_buffer.sv
-    - core/compressed_decoder.sv
-    - core/axi_shim.sv
-    - core/ex_stage.sv
-    - core/mult.sv
-    - core/load_unit.sv
-    - core/cvxif_fu.sv
-    - core/issue_read_operands.sv
-    - core/pmp/src/pmp_entry.sv
-    - core/pmp/src/pmp.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_fma.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_opgroup_fmt_slice.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_divsqrt_multi.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_fma_multi.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_opgroup_multifmt_slice.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_classifier.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_noncomp.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_cast_multi.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_opgroup_block.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_rounding.sv
-    - vendor/pulp-platform/fpnew/src/fpnew_top.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv
-    - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/div_sqrt_mvp_wrapper.sv
-    - core/frontend/frontend.sv
-    - core/frontend/instr_scan.sv
-    - core/frontend/instr_queue.sv
-    - core/frontend/bht.sv
-    - core/frontend/btb.sv
-    - core/frontend/ras.sv
-    - core/cache_subsystem/tag_cmp.sv
-    - core/cache_subsystem/cache_ctrl.sv
-    - core/cache_subsystem/amo_alu.sv
-    - core/cache_subsystem/wt_axi_adapter.sv
-    - core/cache_subsystem/wt_dcache_ctrl.sv
-    - core/cache_subsystem/wt_cache_subsystem.sv
-    - core/cache_subsystem/wt_dcache_missunit.sv
-    - core/cache_subsystem/cva6_icache.sv
-    - core/cache_subsystem/wt_dcache_wbuffer.sv
-    - core/cache_subsystem/wt_l15_adapter.sv
-    - core/cache_subsystem/wt_dcache_mem.sv
-    - core/cache_subsystem/cva6_icache_axi_wrapper.sv
-    - core/cache_subsystem/std_cache_subsystem.sv
-    - core/cache_subsystem/wt_dcache.sv
+      # Top-level source files (not necessarily instantiated at the top of the cva6).
+      - core/ariane.sv
+      - core/cva6.sv
+      - core/alu.sv
+      # Note: depends on fpnew_pkg, above
+      - core/fpu_wrap.sv
+      - core/branch_unit.sv
+      - core/compressed_decoder.sv
+      - core/controller.sv
+      - core/csr_buffer.sv
+      - core/csr_regfile.sv
+      - core/decoder.sv
+      - core/ex_stage.sv
+      - core/instr_realign.sv
+      - core/id_stage.sv
+      - core/issue_read_operands.sv
+      - core/issue_stage.sv
+      - core/load_unit.sv
+      - core/load_store_unit.sv
+      - core/lsu_bypass.sv
+      - core/mult.sv
+      - core/multiplier.sv
+      - core/serdiv.sv
+      - core/perf_counters.sv
+      - core/ariane_regfile_ff.sv
+      - core/ariane_regfile_fpga.sv
+      - core/re_name.sv
+      # NOTE: scoreboard.sv modified for DSIM (unchanged for other simulators)
+      - core/scoreboard.sv
+      - core/store_buffer.sv
+      - core/amo_buffer.sv
+      - core/store_unit.sv
+      - core/commit_stage.sv
+      - core/axi_shim.sv
 
-    # - target: test
-    #   files:
-    #   - corev_apu/tb/ariane_soc_pkg.sv
-    #   - corev_apu/tb/ariane_axi_soc_pkg.sv
-    #   - corev_apu/tb/ariane_testharness.sv
-    #   - corev_apu/tb/ariane_peripherals.sv
-    #   - corev_apu/tb/common/uart.sv
-    #   - corev_apu/tb/common/SimDTM.sv
-    #   - corev_apu/tb/common/SimJTAG.sv
-      
-      
+      # What is "frontend"?
+      - core/frontend/btb.sv
+      - core/frontend/bht.sv
+      - core/frontend/ras.sv
+      - core/frontend/instr_scan.sv
+      - core/frontend/instr_queue.sv
+      - core/frontend/frontend.sv
+
+      # Cache subsystem
+      - core/cache_subsystem/wt_dcache_ctrl.sv
+      - core/cache_subsystem/wt_dcache_mem.sv
+      - core/cache_subsystem/wt_dcache_missunit.sv
+      - core/cache_subsystem/wt_dcache_wbuffer.sv
+      - core/cache_subsystem/wt_dcache.sv
+      - core/cache_subsystem/cva6_icache.sv
+      - core/cache_subsystem/wt_cache_subsystem.sv
+      - core/cache_subsystem/wt_axi_adapter.sv
+
+      # Physical Memory Protection
+      # NOTE: pmp.sv modified for DSIM (unchanged for other simulators)
+      - core/pmp/src/pmp.sv
+      - core/pmp/src/pmp_entry.sv
+
+      # Tracer (behavioral code, not RTL)
+      - include_dirs:
+        - common/local/util
+        files:
+          - common/local/util/instr_tracer_if.sv
+          - common/local/util/instr_tracer.sv
+          - common/local/util/tc_sram_wrapper.sv
+          - common/local/util/sram.sv
+          - vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
+
+    # TODO target define FPGA target + verification etc
+    #   - target: test
+    #     files:
+    #       - corev_apu/riscv-dbg/src/dm_pkg.sv
+    #       - corev_apu/tb/ariane_soc_pkg.sv
+    #       - corev_apu/tb/ariane_axi_soc_pkg.sv
+    #       - corev_apu/tb/ariane_testharness.sv
+    #       - corev_apu/tb/ariane_peripherals.sv
+    #       - corev_apu/tb/common/uart.sv
+    #       - corev_apu/tb/common/SimDTM.sv
+    #       - corev_apu/tb/common/SimJTAG.sv
+
     # - target: not(synthesis)
     #   files:
     #     - common/local/util/instr_tracer.sv
@@ -197,4 +224,3 @@ sources:
     #   - corev_apu/fpga/src/apb_uart/src/slib_clock_div.vhd
     #   - corev_apu/fpga/src/apb_uart/src/slib_fifo.vhd
     #   - corev_apu/fpga/src/apb_uart/src/uart_baudgen.vhd
-

--- a/Bender.yml
+++ b/Bender.yml
@@ -6,13 +6,37 @@ package:
     - "Andreas Kuster <kustera@ethz.ch>"
 
 # WT_DCACHE
+dependencies:
+  axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.31.0 }
+  common_cells:
+    { git: "https://github.com/pulp-platform/common_cells", version: 1.23.0 }
+  fpnew: { git: "https://github.com/pulp-platform/fpnew.git", version: 0.6.2 }
+  tech_cells_generic:
+    {
+      git: "https://github.com/pulp-platform/tech_cells_generic.git",
+      rev: b2a68114302af1d8191ddf34ea0e07b471911866,
+    }
+
+frozen: true
 
 sources:
   - defines:
       WT_DCACHE: 1
-      RVFI_TRACE: 1 # for synthesis has to be deactivate if instr_trace is needed
-      VERILATOR: 1 # used for proper deactivation of instr_trace
     files:
+      # included via target core/include/${TARGET_CFG}_config_pkg.sv
+      - core/include/riscv_pkg.sv
+      - core/include/ariane_dm_pkg.sv
+      - core/include/ariane_pkg.sv
+      # ariane_axi_pkg is dependent on this.
+      - vendor/pulp-platform/axi/src/axi_pkg.sv
+      - core/include/ariane_rvfi_pkg.sv
+
+      # Packages
+      - core/include/ariane_axi_pkg.sv
+      - core/include/wt_cache_pkg.sv
+      - core/include/std_cache_pkg.sv
+      - core/include/axi_intf.sv
+
       - target: cv64a6_imafdc_sv39
         files:
           - core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -43,24 +67,10 @@ sources:
 
       # for all the below files use Flist.cva6 as baseline and also look at Makefile pd/synth
 
-      # FPGA support
+      # FPGA support keep vendoring here because too old
       - vendor/pulp-platform/fpga-support/rtl/SyncDpRam.sv
       - vendor/pulp-platform/fpga-support/rtl/AsyncDpRam.sv
       - vendor/pulp-platform/fpga-support/rtl/AsyncThreePortRam.sv
-
-      # included via target core/include/${TARGET_CFG}_config_pkg.sv
-      - core/include/riscv_pkg.sv
-      - core/include/ariane_dm_pkg.sv
-      - core/include/ariane_pkg.sv
-      # ariane_axi_pkg is dependent on this.
-      - vendor/pulp-platform/axi/src/axi_pkg.sv
-      - core/include/ariane_rvfi_pkg.sv
-
-      # Packages
-      - core/include/ariane_axi_pkg.sv
-      - core/include/wt_cache_pkg.sv
-      - core/include/std_cache_pkg.sv
-      - core/include/axi_intf.sv
 
       # CVXIF
       - core/include/cvxif_pkg.sv
@@ -69,42 +79,42 @@ sources:
       - core/cvxif_example/cvxif_example_coprocessor.sv
       - core/cvxif_example/instr_decoder.sv
 
-      # common cells
-      - include_dirs: [vendor/pulp-platform/common_cells/include/, vendor/pulp-platform/common_cells/src/]
-        files:
-          - vendor/pulp-platform/common_cells/src/cf_math_pkg.sv
-          - vendor/pulp-platform/common_cells/src/fifo_v3.sv
-          - vendor/pulp-platform/common_cells/src/lfsr.sv
-          - vendor/pulp-platform/common_cells/src/lzc.sv
-          - vendor/pulp-platform/common_cells/src/rr_arb_tree.sv
-          - vendor/pulp-platform/common_cells/src/shift_reg.sv
-          - vendor/pulp-platform/common_cells/src/unread.sv
-          - vendor/pulp-platform/common_cells/src/popcount.sv
-          - vendor/pulp-platform/common_cells/src/exp_backoff.sv
-          # Common Cells for example coprocessor
-          - vendor/pulp-platform/common_cells/src/counter.sv
-          - vendor/pulp-platform/common_cells/src/delta_counter.sv
+      # vendored deps
+      # - include_dirs: [vendor/pulp-platform/common_cells/include/, vendor/pulp-platform/common_cells/src/]
+      #   files:
+      #     - vendor/pulp-platform/common_cells/src/cf_math_pkg.sv
+      #     - vendor/pulp-platform/common_cells/src/fifo_v3.sv
+      #     - vendor/pulp-platform/common_cells/src/lfsr.sv
+      #     - vendor/pulp-platform/common_cells/src/lzc.sv
+      #     - vendor/pulp-platform/common_cells/src/rr_arb_tree.sv
+      #     - vendor/pulp-platform/common_cells/src/shift_reg.sv
+      #     - vendor/pulp-platform/common_cells/src/unread.sv
+      #     - vendor/pulp-platform/common_cells/src/popcount.sv
+      #     - vendor/pulp-platform/common_cells/src/exp_backoff.sv
+      #     # Common Cells for example coprocessor
+      #     - vendor/pulp-platform/common_cells/src/counter.sv
+      #     - vendor/pulp-platform/common_cells/src/delta_counter.sv
 
-          # Floating point unit
-          - vendor/pulp-platform/fpnew/src/fpnew_pkg.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_cast_multi.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_classifier.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_divsqrt_multi.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_fma_multi.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_fma.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_noncomp.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_opgroup_block.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_opgroup_fmt_slice.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_opgroup_multifmt_slice.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_rounding.sv
-          - vendor/pulp-platform/fpnew/src/fpnew_top.sv
-          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
-          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv
-          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv
-          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv
-          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv
-          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv
-          - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv
+      # Floating point unit
+      #     - vendor/pulp-platform/fpnew/src/fpnew_pkg.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_cast_multi.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_classifier.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_divsqrt_multi.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_fma_multi.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_fma.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_noncomp.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_opgroup_block.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_opgroup_fmt_slice.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_opgroup_multifmt_slice.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_rounding.sv
+      #     - vendor/pulp-platform/fpnew/src/fpnew_top.sv
+      #     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv
+      #     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv
+      #     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv
+      #     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv
+      #     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv
+      #     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv
+      #     - vendor/pulp-platform/fpnew/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv
 
       # Top-level source files (not necessarily instantiated at the top of the cva6).
       - core/ariane.sv
@@ -164,13 +174,20 @@ sources:
       - core/pmp/src/pmp.sv
       - core/pmp/src/pmp_entry.sv
 
-      # Tracer (behavioral code, not RTL)
       - include_dirs:
-        - common/local/util
+          - common/local/util
         files:
           - common/local/util/tc_sram_wrapper.sv
           - common/local/util/sram.sv
           - vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
+
+      - target: not(synthesis)
+        files:
+          # Tracer (behavioral code, not RTL)
+          - common/local/util/instr_tracer.sv
+          - common/local/util/instr_tracer_if.sv
+          - common/local/util/instr_trace_item.svh
+          - common/local/util/ex_trace_item.svh
 
     # TODO target define FPGA target + verification etc
     #   - target: test
@@ -184,12 +201,6 @@ sources:
     #       - corev_apu/tb/common/SimDTM.sv
     #       - corev_apu/tb/common/SimJTAG.sv
 
-    # - target: not(synthesis)
-    #   files:
-    #     - common/local/util/instr_tracer.sv
-    #     - common/local/util/instr_tracer_if.sv
-    #     - common/local/util/instr_trace_item.svh
-    #     - common/local/util/ex_trace_item.svh
     # - target: all(fpga, xilinx)
     #   files:
     #   - corev_apu/fpga/src/ariane_peripherals_xilinx.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,6 +10,8 @@ package:
 sources:
   - defines:
       WT_DCACHE: 1
+      RVFI_TRACE: 1 # for synthesis has to be deactivate if instr_trace is needed
+      VERILATOR: 1 # used for proper deactivation of instr_trace
     files:
       - target: cv64a6_imafdc_sv39
         files:
@@ -59,7 +61,6 @@ sources:
       - core/include/wt_cache_pkg.sv
       - core/include/std_cache_pkg.sv
       - core/include/axi_intf.sv
-      - core/include/instr_tracer_pkg.sv
 
       # CVXIF
       - core/include/cvxif_pkg.sv
@@ -166,10 +167,7 @@ sources:
       # Tracer (behavioral code, not RTL)
       - include_dirs:
         - common/local/util
-        - core/include
         files:
-          - common/local/util/instr_tracer_if.sv
-          - common/local/util/instr_tracer.sv
           - common/local/util/tc_sram_wrapper.sv
           - common/local/util/sram.sv
           - vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv

--- a/common/local/util/instr_trace_item.svh
+++ b/common/local/util/instr_trace_item.svh
@@ -22,6 +22,8 @@ function string printPCexpr(input logic [63:0] imm);
   end
 endfunction
 
+`include "instr_tracer_pkg.sv"
+
 class instr_trace_item;
     // keep a couple of general purpose information inside this instruction item
     time               simtime;

--- a/core/include/ariane_axi_pkg.sv
+++ b/core/include/ariane_axi_pkg.sv
@@ -22,7 +22,7 @@ package ariane_axi;
 
     localparam IdWidth   = 4; // Recommended by AXI standard
     localparam UserWidth = ariane_pkg::AXI_USER_WIDTH;
-    localparam AddrWidth = 64;
+    localparam AddrWidth = 48;
     localparam DataWidth = 64;
     localparam StrbWidth = DataWidth / 8;
 

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -288,10 +288,10 @@ package ariane_pkg;
 
     localparam FETCH_USER_WIDTH = (cva6_config_pkg::CVA6ConfigFetchUserEn == 0) ? 1: cva6_config_pkg::CVA6ConfigFetchUserWidth;  // Possible cases: between 1 and 64
     localparam DATA_USER_WIDTH = (cva6_config_pkg::CVA6ConfigDataUserEn == 0) ? 1: cva6_config_pkg::CVA6ConfigDataUserWidth;    // Possible cases: between 1 and 64
-    localparam AXI_USER_WIDTH = DATA_USER_WIDTH > FETCH_USER_WIDTH*2 ? DATA_USER_WIDTH : FETCH_USER_WIDTH*2;
+    localparam AXI_USER_WIDTH = 1; // DATA_USER_WIDTH > FETCH_USER_WIDTH*2 ? DATA_USER_WIDTH : FETCH_USER_WIDTH*2;
     localparam DATA_USER_EN = cva6_config_pkg::CVA6ConfigDataUserEn;
     localparam FETCH_USER_EN = cva6_config_pkg::CVA6ConfigFetchUserEn;
-    localparam AXI_USER_EN = cva6_config_pkg::CVA6ConfigDataUserEn | cva6_config_pkg::CVA6ConfigFetchUserEn;
+    localparam AXI_USER_EN = 1; // cva6_config_pkg::CVA6ConfigDataUserEn | cva6_config_pkg::CVA6ConfigFetchUserEn;
 
 
     // ---------------


### PR DESCRIPTION
This is a version of `Bender.yml` that works. However, it does only use the vendored in IPs. I know kind of defying the purpose of bender but still useful for a bender pipeline when cva6 is included.