### PR TITLE
fpu_wrap: Add missing  port

### DIFF
--- a/core/fpu_wrap.sv
+++ b/core/fpu_wrap.sv
@@ -525,6 +525,7 @@ module fpu_wrap import ariane_pkg::*; (
       .int_fmt_i      ( fpnew_pkg::int_format_e'(fpu_ifmt)  ),
       .vectorial_op_i ( fpu_vec_op                          ),
       .tag_i          ( fpu_tag                             ),
+      .simd_mask_i    ( '1                                  ),
       .in_valid_i     ( fpu_in_valid                        ),
       .in_ready_o     ( fpu_in_ready                        ),
       .flush_i,


### PR DESCRIPTION
`fpu_wrap` is missing a port in its instantiation of `fpnew_top`, which this MR adds.

My understanding is that the port was added as part of changes for Ara, so you may want to include this in Ara upstreaming efforts.

EDIT: The cause seems to be a mismatch between bender-declared and vendored dependencies, or at least FPnew (hence the failing CI). I will update this PR once we discussed how to handle this.