### PR TITLE
Add support for Verilator 5 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ VLIB ?= vlib$(questa_version)
 VMAP ?= vmap$(questa_version)
 # verilator version
 verilator      ?= verilator
+verilator_version = $(shell $(verilator) --version | awk  '{split($$2,v,"."); print v[1]}')
 # traget option
 target-options ?=
 # additional definess
@@ -47,9 +48,12 @@ $(warning must set CVA6_REPO_DIR to point at the root of CVA6 sources -- doing i
 export CVA6_REPO_DIR = $(abspath $(root-dir))
 endif
 
-support_verilator_4 := $(shell ($(verilator) --version | grep '4\.') > /dev/null 2>&1 ; echo $$?)
-ifeq ($(support_verilator_4), 0)
+ifeq ($(verilator_version), 4)
 	verilator_threads := 1
+endif
+
+ifeq ($(verilator_version), 5)
+  verilator_5 := 1
 endif
 
 ifndef RISCV
@@ -561,6 +565,7 @@ verilate_command := $(verilator)                                                
                     -Wno-UNOPTFLAT                                                                               \
                     -Wno-BLKANDNBLK                                                                              \
                     -Wno-style                                                                                   \
+                    $(if $(verilator_5),--no-timing)                                                             \
                     $(if ($(PRELOAD)!=""), -DPRELOAD=1,)                                                         \
                     $(if $(DROMAJO), -DDROMAJO=1,)                                                               \
                     $(if $(PROFILE),--stats --stats-vars --profile-cfuncs,)                                      \

--- a/corev_apu/tb/ariane_tb.cpp
+++ b/corev_apu/tb/ariane_tb.cpp
@@ -355,7 +355,7 @@ done_processing:
   size_t mem_size = 0xFFFFFF;
 #if (VERILATOR_VERSION_INTEGER >= 5000000)
   // Verilator v5: Use rootp pointer and .data() accessor.
-  memif.read(0x80000000, mem_size, (void *)top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram.data());
+  memif.read(0x80000000, mem_size, (void *)&top->rootp->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram[0]);
 #else
   // Verilator v4
   memif.read(0x80000000, mem_size, (void *)top->ariane_testharness__DOT__i_sram__DOT__gen_cut__BRA__0__KET____DOT__gen_mem__DOT__i_tc_sram_wrapper__DOT__i_tc_sram__DOT__sram);


### PR DESCRIPTION
I included a fix (workaround(?)) for compiling on g++-11.2.0 and g++-9.2.0


 It is unclear to me why it crashes. Here is the log:

```
/usr/pack/verilator-5.006-zr/verilator-5.006/include/verilated_types.h:1014:38: error: cannot convert 'long unsigned int*' to 'WData*' {aka 'unsigned int*'} in return
 1014 |     WData* data() { return &m_storage[0]; }
      |                             ~~~~~~~~~^
      |                                      |
      |                                      long unsigned int*
make[1]: *** [Variane_testharness.mk:72: ariane_tb.o] Error 1

```