### PR TITLE
Remove `translate_off` directive from `tc_sram_wrapper`.

### DIFF
--- a/common/local/util/tc_sram_wrapper.sv
+++ b/common/local/util/tc_sram_wrapper.sv
@@ -34,8 +34,6 @@ module tc_sram_wrapper #(
   output data_t [NumPorts-1:0] rdata_o     // read data
 );
 
-// synthesis translate_off
-
   tc_sram #(
     .NumWords(NumWords),
     .DataWidth(DataWidth),
@@ -54,7 +52,5 @@ module tc_sram_wrapper #(
       .addr_i   ( addr_i  ),
       .rdata_o  ( rdata_o )
     );
-
-// synthesis translate_on
 
 endmodule


### PR DESCRIPTION
Not sure if that `translate_off` is there for a reason. Since we use the `tc_sram` module for ASIC and FPGA, I guess we could remove it. If you'd prefer to go for a bender-based solution (adding a target and having another version of `tc_sram_wrapper` for ASIC synthesis), it's also fine for me! 