### PR TITLE
Update clic to v2.0.0

### DIFF
--- a/ci/build-riscv-tests.sh
+++ b/ci/build-riscv-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-VERSION="19760b7a7d72227376d91b1afb0f13915c233efb"
+VERSION="daf8bcdb5adec24ab88907df57d8217945e5d463"
 
 cd $ROOT/tmp
 


### PR DESCRIPTION
There have a been a bunch of fixes

* Fix interrupt enable bit offset in registers
* Fix configuration of mnlbits saturation logic (register was unconfigurable)