### PR TITLE
Update cv32a6_embedded_config_pkg.sv

### DIFF
--- a/core/include/cv32a6_embedded_config_pkg.sv
+++ b/core/include/cv32a6_embedded_config_pkg.sv
@@ -26,7 +26,8 @@ package cva6_config_pkg;
     localparam CVA6ConfigCExtEn = 1;
     localparam CVA6ConfigAExtEn = 0;
     localparam CVA6ConfigBExtEn = 1;
-
+    localparam CVA6ConfigVExtEn = 0;
+  
     localparam CVA6ConfigAxiIdWidth = 4;
     localparam CVA6ConfigAxiAddrWidth = 64;
     localparam CVA6ConfigAxiDataWidth = 64;


### PR DESCRIPTION
    localparam CVA6ConfigVExtEn was not defined, that's why synhtesis fails.