### PR TITLE
[FIX] WFI in clic mode

### DIFF
--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1937,7 +1937,7 @@ module csr_regfile import ariane_pkg::*; #(
         wfi_d = wfi_q;
         // if there is any (enabled) interrupt pending un-stall the core
         // also un-stall if we want to enter debug mode
-        if (|(mip_q & mie_q) || debug_req_i || irq_i[1]) begin
+        if (debug_req_i || (!clic_mode_o && (|(mip_q & mie_q) || irq_i[1])) || clic_irq_ready_o) begin
             wfi_d = 1'b0;
         // or alternatively if there is no exception pending and we are not in debug mode wait here
         // for the interrupt


### PR DESCRIPTION
When running in CLIC mode, interrupts being taken by the core are not triggering the de-assertion of the wfi_d signal.