### PR TITLE
[FIX] Prevent spurious interrupts from being generated when in CLIC mode

### DIFF
--- a/core/decoder.sv
+++ b/core/decoder.sv
@@ -1391,8 +1391,10 @@ module decoder import ariane_pkg::*; #(
             // -----------------
             // we decode an interrupt the same as an exception, hence it will be taken if the instruction did not
             // throw any previous exception.
-            if (ariane_pkg::RVSCLIC && clic_mode_i && clic_irq_req_i) begin
-                interrupt_cause = clic_irq_cause_i;
+            if (ariane_pkg::RVSCLIC && clic_mode_i) begin
+                if (clic_irq_req_i) begin
+                    interrupt_cause = clic_irq_cause_i;
+                end
             end else begin
                 // we have three interrupt sources: external interrupts, software interrupts, timer interrupts (order of precedence)
                 // for two privilege levels: Supervisor and Machine Mode


### PR DESCRIPTION
Spurious interrupts are generated when running in CLIC mode. The else branch of the if condition should not be executed when running in CLIC mode, regardless of whether an interrupt is pending or not.