### PR TITLE
[FIX] Take all CLIC interrupts when in U-mode

### DIFF
--- a/core/cva6_clic_controller.sv
+++ b/core/cva6_clic_controller.sv
@@ -59,10 +59,7 @@ module cva6_clic_controller #(
       end
       riscv::PRIV_LVL_U: begin
         // Take all M-mode and S-mode interrupts
-        clic_irq_req_o = ((clic_irq_valid_i) &&
-                          ((clic_irq_priv_i == riscv::PRIV_LVL_M) ||
-                           (clic_irq_priv_i == riscv::PRIV_LVL_S && irq_ctrl_i.sie)));
-
+        clic_irq_req_o = clic_irq_valid_i;
       end
       default: clic_irq_req_o = 1'b0;
     endcase


### PR DESCRIPTION
When running in User mode, interrupts should be considered always globally enabled for S and M modes. 