### PR TITLE
Ara MMU Support

### DIFF
--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -38,6 +38,13 @@ module acc_dispatcher import ariane_pkg::*; import riscv::*; (
     input  logic                                  commit_st_barrier_i,  // A store barrier was commited
     // Interface with the load/store unit
     input  logic                                  acc_no_st_pending_i,
+    output logic                                  acc_mmu_req_o,
+    output logic [riscv::VLEN-1:0]                acc_vaddr_o,
+    output logic                                  acc_is_store_o,
+
+    input logic                                   acc_mmu_valid_i,
+    input logic [riscv::PLEN-1:0]                 acc_paddr_i,
+    input exception_t                             acc_exception_i,
     // Interface with the controller
     output logic                                  ctrl_halt_o,
     input  logic                                  flush_unissued_instr_i,
@@ -70,6 +77,15 @@ module acc_dispatcher import ariane_pkg::*; import riscv::*; (
                           issue_instr_hs_i &
                           (issue_instr_i.fu == ACCEL) &
                           ~flush_unissued_instr_i;
+  
+  assign acc_mmu_req_o  = acc_resp_i.mmu_req;
+  assign acc_vaddr_o    = acc_resp_i.vaddr;
+  assign acc_is_store_o = acc_resp_i.is_store;
+
+  assign acc_req_o.mmu_valid = acc_mmu_valid_i;
+  assign acc_req_o.paddr     = acc_paddr_i;
+  assign acc_req_o.exception = acc_exception_i;
+
 
   // Accelerator load/store pending signals
   logic acc_no_ld_pending;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -858,7 +858,7 @@ module cva6 import ariane_pkg::*; #(
   logic                   acc_is_store;
   logic                   acc_mmu_valid;
   logic [riscv::PLEN-1:0] acc_paddr;
-  exception_t             acc_exception_o;
+  exception_t             acc_exception;
 
   if (ENABLE_ACCELERATOR) begin: gen_accelerator
     acc_pkg::accelerator_req_t acc_req;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -550,7 +550,13 @@ module cva6 import ariane_pkg::*; #(
     .mem_paddr_o            ( mem_paddr                   ),
     .lsu_rmask_o            ( lsu_rmask                   ),
     .lsu_wmask_o            ( lsu_wmask                   ),
-    .lsu_addr_trans_id_o    ( lsu_addr_trans_id           )
+    .lsu_addr_trans_id_o    ( lsu_addr_trans_id           ),
+    .x_mmu_req_i            ( acc_mmu_req                 ),
+    .x_vaddr_i              ( acc_vaddr                   ),
+    .x_is_store_i           ( acc_is_store                ),
+    .x_mmu_valid_o          ( acc_mmu_valid               ),
+    .x_paddr_o              ( acc_paddr                   ),
+    .x_mmu_exception_o      ( acc_exception               )
   );
 
   // ---------
@@ -847,6 +853,13 @@ module cva6 import ariane_pkg::*; #(
   // Accelerator
   // ----------------
 
+  logic                   acc_mmu_req;
+  logic [riscv::VLEN-1:0] acc_vaddr;
+  logic                   acc_is_store;
+  logic                   acc_mmu_valid;
+  logic [riscv::PLEN-1:0] acc_paddr;
+  exception_t             acc_exception_o;
+
   if (ENABLE_ACCELERATOR) begin: gen_accelerator
     acc_pkg::accelerator_req_t acc_req;
 
@@ -871,6 +884,12 @@ module cva6 import ariane_pkg::*; #(
       .acc_valid_ex_o         ( acc_valid_acc_ex             ),
       .commit_ack_i           ( commit_ack                   ),
       .acc_no_st_pending_i    ( no_st_pending_commit         ),
+      .acc_mmu_req_o          ( acc_mmu_req                  ),
+      .acc_vaddr_o            ( acc_vaddr                    ),
+      .acc_is_store_o         ( acc_is_store                 ),
+      .acc_mmu_valid_i        ( acc_mmu_valid                ),
+      .acc_paddr_i            ( acc_paddr                    ),
+      .acc_exception_i        ( acc_exception                ),
       .ctrl_halt_o            ( halt_acc_ctrl                ),
       .acc_req_o              ( acc_req                      ),
       .acc_resp_i             ( cvxif_resp_i                 )

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -125,7 +125,15 @@ module ex_stage import ariane_pkg::*; #(
     output [riscv::PLEN-1:0]                       mem_paddr_o,
     output [(riscv::XLEN/8)-1:0]                   lsu_rmask_o,
     output [(riscv::XLEN/8)-1:0]                   lsu_wmask_o,
-    output [ariane_pkg::TRANS_ID_BITS-1:0]         lsu_addr_trans_id_o
+    output [ariane_pkg::TRANS_ID_BITS-1:0]         lsu_addr_trans_id_o,
+
+    // ACC interface
+    input logic                                     x_mmu_req_i,
+    input logic [riscv::VLEN-1:0]                   x_vaddr_i,
+    input logic                                     x_is_store_i,
+    output logic                                    x_mmu_valid_o,
+    output logic [riscv::PLEN-1:0]                  x_paddr_o,
+    output exception_t                              x_mmu_exception_o
 );
 
     // -------------------------
@@ -350,7 +358,13 @@ module ex_stage import ariane_pkg::*; #(
         .mem_paddr_o,
         .lsu_rmask_o,
         .lsu_wmask_o,
-        .lsu_addr_trans_id_o
+        .lsu_addr_trans_id_o,
+        .x_mmu_req_i,
+        .x_vaddr_i,
+        .x_is_store_i,
+        .x_mmu_valid_o,
+        .x_paddr_o,
+        .x_exception_o (x_mmu_exception_o)
     );
 
     if (CVXIF_PRESENT) begin : gen_cvxif

--- a/core/include/acc_pkg.sv
+++ b/core/include/acc_pkg.sv
@@ -25,6 +25,9 @@ package acc_pkg;
     // Invalidation interface
     logic                                 acc_cons_en;
     logic                                 inval_ready;
+    logic                                 mmu_valid;//from mmu
+    logic [riscv::PLEN-1:0]               paddr;//from mmu
+    ariane_pkg::exception_t               exception;//from mmu
   } accelerator_req_t;
 
   typedef struct packed {
@@ -42,6 +45,9 @@ package acc_pkg;
     // Invalidation interface
     logic                                 inval_valid;
     logic [63:0]                          inval_addr;
+    logic                                 mmu_req;// to MMU
+    logic [riscv::VLEN-1:0]               vaddr;// to MMU
+    logic                                 is_store;// to MMU
   } accelerator_resp_t;
 
 endpackage

--- a/core/include/cvxif_pkg.sv
+++ b/core/include/cvxif_pkg.sv
@@ -83,28 +83,34 @@ package cvxif_pkg;
     } x_result_t ;
 
     typedef struct packed {
-        logic               x_compressed_valid;
-        x_compressed_req_t  x_compressed_req;
-        logic               x_issue_valid;
-        x_issue_req_t       x_issue_req;
-        logic               x_commit_valid;
-        x_commit_t          x_commit;
-        logic               x_mem_ready;
-        x_mem_resp_t        x_mem_resp;
-        logic               x_mem_result_valid;
-        x_mem_result_t      x_mem_result;
-        logic               x_result_ready;
+        logic                   x_compressed_valid;
+        x_compressed_req_t      x_compressed_req;
+        logic                   x_issue_valid;
+        x_issue_req_t           x_issue_req;
+        logic                   x_commit_valid;
+        x_commit_t              x_commit;
+        logic                   x_mem_ready;
+        x_mem_resp_t            x_mem_resp;
+        logic                   x_mem_result_valid;
+        x_mem_result_t          x_mem_result;
+        logic                   x_result_ready;
+        logic                   x_mmu_valid;
+        logic [riscv::PLEN-1:0] x_mmu_paddr;
+        ariane_pkg::exception_t x_mmu_exception;
     } cvxif_req_t;
 
     typedef struct packed {
-        logic               x_compressed_ready;
-        x_compressed_resp_t x_compressed_resp;
-        logic               x_issue_ready;
-        x_issue_resp_t      x_issue_resp;
-        logic               x_mem_valid;
-        x_mem_req_t         x_mem_req;
-        logic               x_result_valid;
-        x_result_t          x_result;
+        logic                   x_compressed_ready;
+        x_compressed_resp_t     x_compressed_resp;
+        logic                   x_issue_ready;
+        x_issue_resp_t          x_issue_resp;
+        logic                   x_mem_valid;
+        x_mem_req_t             x_mem_req;
+        logic                   x_result_valid;
+        x_result_t              x_result;
+        logic                   x_mmu_req;
+        logic [riscv::VLEN-1:0] x_mmu_vaddr;
+        logic                   x_is_store;
     } cvxif_resp_t;
 
 endpackage


### PR DESCRIPTION
This PR is adding the interface from ARA to Ariane's MMU for address translation request. In Ariane's load store unit, arbiter has been implemented before MMU to arbitrate the scalar and vector requests.