### PR TITLE
Add synchronous clear

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -9,7 +9,7 @@ package:
 dependencies:
   axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.31.0 }
   common_cells:
-    { git: "https://github.com/pulp-platform/common_cells", version: 1.23.0 }
+    { git: "https://github.com/pulp-platform/common_cells", rev: bd4bbe7 } # branch: yt/synch-clear
   fpnew: { git: "https://github.com/pulp-platform/cvfpu.git", rev: pulp-v0.1.1 }
   tech_cells_generic:
     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13 }

--- a/Bender.yml
+++ b/Bender.yml
@@ -9,7 +9,7 @@ package:
 dependencies:
   axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.31.0 }
   common_cells:
-    { git: "https://github.com/pulp-platform/common_cells", rev: bd4bbe7 } # branch: yt/synch-clear
+    { git: "https://github.com/pulp-platform/common_cells", version: 1.35.0  }
   fpnew: { git: "https://github.com/pulp-platform/cvfpu.git", rev: pulp-v0.1.1 }
   tech_cells_generic:
     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13 }

--- a/common/local/util/sram_pulp.sv
+++ b/common/local/util/sram_pulp.sv
@@ -25,7 +25,7 @@ module sram #(
     parameter USER_WIDTH = 1,
     parameter USER_EN    = 0,
     parameter NUM_WORDS  = 1024,
-    parameter SIM_INIT   = "none",
+    parameter SIM_INIT   = "zeros",
     parameter OUT_REGS   = 0     // enables output registers in FPGA macro (read lat = 2)
 )(
    input  logic                          clk_i,

--- a/core/ariane_regfile_ff.sv
+++ b/core/ariane_regfile_ff.sv
@@ -31,6 +31,7 @@ module ariane_regfile #(
     // clock and reset
     input  logic                                             clk_i,
     input  logic                                             rst_ni,
+    input  logic                                             clear_i,
     // disable clock gates for testing
     input  logic                                             test_en_i,
     // read port
@@ -63,14 +64,18 @@ module ariane_regfile #(
     if (~rst_ni) begin
       mem <= '{default: '0};
     end else begin
-      for (int unsigned j = 0; j < CVA6Cfg.NrCommitPorts; j++) begin
-        for (int unsigned i = 0; i < NUM_WORDS; i++) begin
-          if (we_dec[j][i]) begin
-            mem[i] <= wdata_i[j];
+      if (clear_i) begin
+        mem <= '{default: '0};
+      end else begin
+        for (int unsigned j = 0; j < CVA6Cfg.NrCommitPorts; j++) begin
+          for (int unsigned i = 0; i < NUM_WORDS; i++) begin
+            if (we_dec[j][i]) begin
+              mem[i] <= wdata_i[j];
+            end
           end
-        end
-        if (ZERO_REG_ZERO) begin
-          mem[0] <= '0;
+          if (ZERO_REG_ZERO) begin
+            mem[0] <= '0;
+          end
         end
       end
     end

--- a/core/axi_shim.sv
+++ b/core/axi_shim.sv
@@ -18,6 +18,7 @@
  *
  */
 
+`include "common_cells/registers.svh"
 
 module axi_shim #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
@@ -27,6 +28,7 @@ module axi_shim #(
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,  // Synchronous clear active high
     // read channel
     // request
     input logic rd_req_i,
@@ -283,16 +285,8 @@ module axi_shim #(
   // ----------------
   // Registers
   // ----------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      // start in flushing state and initialize the memory
-      wr_state_q <= IDLE;
-      wr_cnt_q   <= '0;
-    end else begin
-      wr_state_q <= wr_state_d;
-      wr_cnt_q   <= wr_cnt_d;
-    end
-  end
+  `FFARNC(wr_state_q, wr_state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(wr_cnt_q  , wr_cnt_d  , clear_i, '0, clk_i, rst_ni)
 
   // ----------------
   // Assertions

--- a/core/axi_shim.sv
+++ b/core/axi_shim.sv
@@ -286,7 +286,7 @@ module axi_shim #(
   // Registers
   // ----------------
   `FFARNC(wr_state_q, wr_state_d, clear_i, IDLE, clk_i, rst_ni)
-  `FFARNC(wr_cnt_q  , wr_cnt_d  , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(wr_cnt_q, wr_cnt_d, clear_i, '0, clk_i, rst_ni)
 
   // ----------------
   // Assertions

--- a/core/cache_subsystem/axi_adapter.sv
+++ b/core/cache_subsystem/axi_adapter.sv
@@ -16,6 +16,8 @@
  */
 //import std_cache_pkg::*;
 
+`include "common_cells/registers.svh"
+
 module axi_adapter #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter int unsigned DATA_WIDTH = 256,
@@ -461,28 +463,14 @@ module axi_adapter #(
   // ----------------
   // Registers
   // ----------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      // start in flushing state and initialize the memory
-      state_q              <= IDLE;
-      cnt_q                <= '0;
-      cache_line_q         <= '0;
-      addr_offset_q        <= '0;
-      id_q                 <= '0;
-      amo_q                <= ariane_pkg::AMO_NONE;
-      size_q               <= '0;
-      outstanding_aw_cnt_q <= '0;
-    end else begin
-      state_q              <= state_d;
-      cnt_q                <= cnt_d;
-      cache_line_q         <= cache_line_d;
-      addr_offset_q        <= addr_offset_d;
-      id_q                 <= id_d;
-      amo_q                <= amo_d;
-      size_q               <= size_d;
-      outstanding_aw_cnt_q <= outstanding_aw_cnt_d;
-    end
-  end
+  `FFARNC(state_q              , state_d             , 1'b0, IDLE                , clk_i, rst_ni)
+  `FFARNC(cnt_q                , cnt_d               , 1'b0, '0                  , clk_i, rst_ni)
+  `FFARNC(cache_line_q         , cache_line_d        , 1'b0, '0                  , clk_i, rst_ni)
+  `FFARNC(addr_offset_q        , addr_offset_d       , 1'b0, '0                  , clk_i, rst_ni)
+  `FFARNC(id_q                 , id_d                , 1'b0, '0                  , clk_i, rst_ni)
+  `FFARNC(amo_q                , amo_d               , 1'b0, ariane_pkg::AMO_NONE, clk_i, rst_ni)
+  `FFARNC(size_q               , size_d              , 1'b0, '0                  , clk_i, rst_ni)
+  `FFARNC(outstanding_aw_cnt_q , outstanding_aw_cnt_d, 1'b0, '0                  , clk_i, rst_ni)
 
   function automatic axi_pkg::atop_t atop_from_amo(ariane_pkg::amo_t amo);
     axi_pkg::atop_t result = 6'b000000;

--- a/core/cache_subsystem/axi_adapter.sv
+++ b/core/cache_subsystem/axi_adapter.sv
@@ -463,14 +463,14 @@ module axi_adapter #(
   // ----------------
   // Registers
   // ----------------
-  `FFARNC(state_q              , state_d             , 1'b0, IDLE                , clk_i, rst_ni)
-  `FFARNC(cnt_q                , cnt_d               , 1'b0, '0                  , clk_i, rst_ni)
-  `FFARNC(cache_line_q         , cache_line_d        , 1'b0, '0                  , clk_i, rst_ni)
-  `FFARNC(addr_offset_q        , addr_offset_d       , 1'b0, '0                  , clk_i, rst_ni)
-  `FFARNC(id_q                 , id_d                , 1'b0, '0                  , clk_i, rst_ni)
-  `FFARNC(amo_q                , amo_d               , 1'b0, ariane_pkg::AMO_NONE, clk_i, rst_ni)
-  `FFARNC(size_q               , size_d              , 1'b0, '0                  , clk_i, rst_ni)
-  `FFARNC(outstanding_aw_cnt_q , outstanding_aw_cnt_d, 1'b0, '0                  , clk_i, rst_ni)
+  `FFARNC(state_q, state_d, 1'b0, IDLE, clk_i, rst_ni)
+  `FFARNC(cnt_q, cnt_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(cache_line_q, cache_line_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(addr_offset_q, addr_offset_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(id_q, id_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(amo_q, amo_d, 1'b0, ariane_pkg::AMO_NONE, clk_i, rst_ni)
+  `FFARNC(size_q, size_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(outstanding_aw_cnt_q, outstanding_aw_cnt_d, 1'b0, '0, clk_i, rst_ni)
 
   function automatic axi_pkg::atop_t atop_from_amo(ariane_pkg::amo_t amo);
     axi_pkg::atop_t result = 6'b000000;

--- a/core/cache_subsystem/axi_adapter.sv
+++ b/core/cache_subsystem/axi_adapter.sv
@@ -26,10 +26,9 @@ module axi_adapter #(
     parameter type axi_req_t = logic,
     parameter type axi_rsp_t = logic
 ) (
-    input logic clk_i,  // Clock
-    input logic rst_ni, // Asynchronous reset active low
+    input logic clk_i,
+    input logic rst_ni,
     input logic clear_i,
-
     output logic busy_o,
     input logic req_i,
     input ariane_pkg::ad_req_t type_i,

--- a/core/cache_subsystem/axi_adapter.sv
+++ b/core/cache_subsystem/axi_adapter.sv
@@ -28,6 +28,7 @@ module axi_adapter #(
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni, // Asynchronous reset active low
+    input logic clear_i,
 
     output logic busy_o,
     input logic req_i,
@@ -463,14 +464,14 @@ module axi_adapter #(
   // ----------------
   // Registers
   // ----------------
-  `FFARNC(state_q, state_d, 1'b0, IDLE, clk_i, rst_ni)
-  `FFARNC(cnt_q, cnt_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(cache_line_q, cache_line_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(addr_offset_q, addr_offset_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(id_q, id_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(amo_q, amo_d, 1'b0, ariane_pkg::AMO_NONE, clk_i, rst_ni)
-  `FFARNC(size_q, size_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(outstanding_aw_cnt_q, outstanding_aw_cnt_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(cnt_q, cnt_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(cache_line_q, cache_line_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(addr_offset_q, addr_offset_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(id_q, id_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(amo_q, amo_d, clear_i, ariane_pkg::AMO_NONE, clk_i, rst_ni)
+  `FFARNC(size_q, size_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(outstanding_aw_cnt_q, outstanding_aw_cnt_d, clear_i, '0, clk_i, rst_ni)
 
   function automatic axi_pkg::atop_t atop_from_amo(ariane_pkg::amo_t amo);
     axi_pkg::atop_t result = 6'b000000;

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -444,9 +444,9 @@ module cache_ctrl
   // --------------
   // Registers
   // --------------
-  `FFARNC(state_q   , state_d  , clear_i, IDLE, clk_i, rst_ni)
-  `FFARNC(mem_req_q , mem_req_d, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(hit_way_q , hit_way_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(mem_req_q, mem_req_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(hit_way_q, hit_way_d, clear_i, '0, clk_i, rst_ni)
 
   //pragma translate_off
 `ifndef VERILATOR

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -27,6 +27,7 @@ module cache_ctrl
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,  // Synchronous clear active high
     input logic bypass_i,  // enable cache
     output logic busy_o,
     input logic stall_i,  // stall new memory requests
@@ -443,9 +444,9 @@ module cache_ctrl
   // --------------
   // Registers
   // --------------
-  `FFARNC(state_q   , state_d  , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(mem_req_q , mem_req_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(hit_way_q , hit_way_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(state_q   , state_d  , clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(mem_req_q , mem_req_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(hit_way_q , hit_way_d, clear_i, '0, clk_i, rst_ni)
 
   //pragma translate_off
 `ifndef VERILATOR

--- a/core/cache_subsystem/cache_ctrl.sv
+++ b/core/cache_subsystem/cache_ctrl.sv
@@ -17,6 +17,7 @@
 //
 // Description: Cache controller
 
+`include "common_cells/registers.svh"
 
 module cache_ctrl
   import ariane_pkg::*;
@@ -442,17 +443,9 @@ module cache_ctrl
   // --------------
   // Registers
   // --------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      state_q   <= IDLE;
-      mem_req_q <= '0;
-      hit_way_q <= '0;
-    end else begin
-      state_q   <= state_d;
-      mem_req_q <= mem_req_d;
-      hit_way_q <= hit_way_d;
-    end
-  end
+  `FFARNC(state_q   , state_d  , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(mem_req_q , mem_req_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(hit_way_q , hit_way_d, 1'b0, '0, clk_i, rst_ni)
 
   //pragma translate_off
 `ifndef VERILATOR

--- a/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
@@ -29,6 +29,7 @@ module cva6_hpdcache_if_adapter
     //  Clock and active-low reset pins
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
 
     //  Port ID
     input hpdcache_pkg::hpdcache_req_sid_t hpdcache_req_sid_i,
@@ -202,7 +203,7 @@ module cva6_hpdcache_if_adapter
               ( cva6_amo_req_i.req  & hpdcache_req_ready_i & ~amo_pending_q) |
               (~cva6_amo_resp_o.ack & amo_pending_q);
 
-      `FFARNC(amo_pending_q, amo_pending_n, 1'b0, 1'b0, clk_i, rst_ni)
+      `FFARNC(amo_pending_q, amo_pending_n, clear_i, 1'b0, clk_i, rst_ni)
     end
 
     //  }}}

--- a/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
@@ -9,6 +9,9 @@
 // Authors: Cesar Fuguet
 // Date: February, 2023
 // Description: Interface adapter for the CVA6 core
+
+`include "common_cells/registers.svh"
+
 module cva6_hpdcache_if_adapter
   import hpdcache_pkg::*;
 
@@ -108,7 +111,7 @@ module cva6_hpdcache_if_adapter
       logic             [ 7:0] amo_data_be;
       hpdcache_req_op_t        amo_op;
       logic             [31:0] amo_resp_word;
-      logic                    amo_pending_q;
+      logic                    amo_pending_q, amo_pending_n;
 
       //  AMO logic
       //  {{{
@@ -195,16 +198,12 @@ module cva6_hpdcache_if_adapter
                                                         : hpdcache_rsp_i.rdata[0];
       //  }}}
 
-      always_ff @(posedge clk_i or negedge rst_ni) begin : amo_pending_ff
-        if (!rst_ni) begin
-          amo_pending_q <= 1'b0;
-        end else begin
-          amo_pending_q <=
+      assign amo_pending_n =
               ( cva6_amo_req_i.req  & hpdcache_req_ready_i & ~amo_pending_q) |
               (~cva6_amo_resp_o.ack & amo_pending_q);
-        end
-      end
-    end
+
+      `FFARNC(amo_pending_q, amo_pending_n, 1'b0, 1'b0, clk_i, rst_ni)
+
     //  }}}
   endgenerate
   //  }}}

--- a/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
@@ -203,6 +203,7 @@ module cva6_hpdcache_if_adapter
               (~cva6_amo_resp_o.ack & amo_pending_q);
 
       `FFARNC(amo_pending_q, amo_pending_n, 1'b0, 1'b0, clk_i, rst_ni)
+    end
 
     //  }}}
   endgenerate

--- a/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
@@ -111,7 +111,7 @@ module cva6_hpdcache_if_adapter
       logic             [ 7:0] amo_data_be;
       hpdcache_req_op_t        amo_op;
       logic             [31:0] amo_resp_word;
-      logic                    amo_pending_q, amo_pending_n;
+      logic amo_pending_q, amo_pending_n;
 
       //  AMO logic
       //  {{{

--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -227,6 +227,7 @@ module cva6_hpdcache_subsystem
       ) i_cva6_hpdcache_load_if_adapter (
           .clk_i,
           .rst_ni,
+          .clear_i('0),
 
           .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(r)),
 
@@ -253,6 +254,7 @@ module cva6_hpdcache_subsystem
     ) i_cva6_hpdcache_store_if_adapter (
         .clk_i,
         .rst_ni,
+        .clear_i('0),
 
         .hpdcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts - 1)),
 
@@ -279,6 +281,7 @@ module cva6_hpdcache_subsystem
     ) i_cva6_hpdcache_cmo_if_adapter (
         .clk_i,
         .rst_ni,
+        .clear_i('0),
 
         .dcache_req_sid_i(hpdcache_pkg::hpdcache_req_sid_t'(NumPorts)),
 

--- a/core/cache_subsystem/cva6_hpdcache_subsystem.sv
+++ b/core/cache_subsystem/cva6_hpdcache_subsystem.sv
@@ -109,6 +109,7 @@ module cva6_hpdcache_subsystem
   ) i_cva6_icache (
       .clk_i         (clk_i),
       .rst_ni        (rst_ni),
+      .clear_i       (1'b0),
       .flush_i       (icache_flush_i),
       .en_i          (icache_en_i),
       .miss_o        (icache_miss_o),

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -36,6 +36,7 @@ module cva6_icache
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
 
     /// flush the icache, flush and kill have to be asserted together
     input  logic         flush_i,
@@ -495,16 +496,16 @@ module cva6_icache
     );
   end
 
-  `FFARNC(cl_tag_q      , cl_tag_d     , 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(flush_cnt_q   , flush_cnt_d  , 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(vaddr_q       , vaddr_d      , 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(cmp_en_q      , cmp_en_d     , 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(cache_en_q    , cache_en_d   , 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(flush_q       , flush_d      , 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(state_q       , state_d      , 1'b0, FLUSH, clk_i, rst_ni)
-  `FFARNC(cl_offset_q   , cl_offset_d  , 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(repl_way_oh_q , repl_way_oh_d, 1'b0, '0   , clk_i, rst_ni)
-  `FFARNC(inv_q         , inv_d        , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(cl_tag_q, cl_tag_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(flush_cnt_q, flush_cnt_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vaddr_q, vaddr_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(cmp_en_q, cmp_en_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(cache_en_q, cache_en_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(flush_q, flush_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, FLUSH, clk_i, rst_ni)
+  `FFARNC(cl_offset_q, cl_offset_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(repl_way_oh_q, repl_way_oh_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(inv_q, inv_d, clear_i, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -545,17 +545,17 @@ module cva6_icache
       vld_mirror <= '{default: '0};
       tag_mirror <= '{default: '0};
     end else begin
-      // if (clear_i) begin
-      //   vld_mirror <= '{default: '0};
-      //   tag_mirror <= '{default: '0};
-      // end else begin
+      if (clear_i) begin
+        vld_mirror <= '{default: '0};
+        tag_mirror <= '{default: '0};
+      end else begin
         for (int i = 0; i < ICACHE_SET_ASSOC; i++) begin
           if (vld_req[i] & vld_we) begin
             vld_mirror[vld_addr][i] <= vld_wdata[i];
             tag_mirror[vld_addr][i] <= cl_tag_q;
           end
         end
-      // end
+      end
     end
   end
 

--- a/core/cache_subsystem/cva6_icache.sv
+++ b/core/cache_subsystem/cva6_icache.sv
@@ -24,6 +24,7 @@
 // 3) NC accesses to I/O space are expected to return 32bit from memory.
 //
 
+`include "common_cells/registers.svh"
 
 module cva6_icache
   import ariane_pkg::*;
@@ -494,32 +495,16 @@ module cva6_icache
     );
   end
 
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
-    if (!rst_ni) begin
-      cl_tag_q      <= '0;
-      flush_cnt_q   <= '0;
-      vaddr_q       <= '0;
-      cmp_en_q      <= '0;
-      cache_en_q    <= '0;
-      flush_q       <= '0;
-      state_q       <= FLUSH;
-      cl_offset_q   <= '0;
-      repl_way_oh_q <= '0;
-      inv_q         <= '0;
-    end else begin
-      cl_tag_q      <= cl_tag_d;
-      flush_cnt_q   <= flush_cnt_d;
-      vaddr_q       <= vaddr_d;
-      cmp_en_q      <= cmp_en_d;
-      cache_en_q    <= cache_en_d;
-      flush_q       <= flush_d;
-      state_q       <= state_d;
-      cl_offset_q   <= cl_offset_d;
-      repl_way_oh_q <= repl_way_oh_d;
-      inv_q         <= inv_d;
-    end
-  end
+  `FFARNC(cl_tag_q      , cl_tag_d     , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(flush_cnt_q   , flush_cnt_d  , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(vaddr_q       , vaddr_d      , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(cmp_en_q      , cmp_en_d     , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(cache_en_q    , cache_en_d   , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(flush_q       , flush_d      , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(state_q       , state_d      , 1'b0, FLUSH, clk_i, rst_ni)
+  `FFARNC(cl_offset_q   , cl_offset_d  , 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(repl_way_oh_q , repl_way_oh_d, 1'b0, '0   , clk_i, rst_ni)
+  `FFARNC(inv_q         , inv_d        , 1'b0, '0   , clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions
@@ -559,12 +544,17 @@ module cva6_icache
       vld_mirror <= '{default: '0};
       tag_mirror <= '{default: '0};
     end else begin
-      for (int i = 0; i < ICACHE_SET_ASSOC; i++) begin
-        if (vld_req[i] & vld_we) begin
-          vld_mirror[vld_addr][i] <= vld_wdata[i];
-          tag_mirror[vld_addr][i] <= cl_tag_q;
+      // if (clear_i) begin
+      //   vld_mirror <= '{default: '0};
+      //   tag_mirror <= '{default: '0};
+      // end else begin
+        for (int i = 0; i < ICACHE_SET_ASSOC; i++) begin
+          if (vld_req[i] & vld_we) begin
+            vld_mirror[vld_addr][i] <= vld_wdata[i];
+            tag_mirror[vld_addr][i] <= cl_tag_q;
+          end
         end
-      end
+      // end
     end
   end
 

--- a/core/cache_subsystem/cva6_icache_axi_wrapper.sv
+++ b/core/cache_subsystem/cva6_icache_axi_wrapper.sv
@@ -25,6 +25,7 @@ module cva6_icache_axi_wrapper
 ) (
     input logic             clk_i,
     input logic             rst_ni,
+    input logic             clear_i,
     input riscv::priv_lvl_t priv_lvl_i,
 
     input logic flush_i,  // flush the icache, flush and kill have to be asserted together
@@ -111,6 +112,7 @@ module cva6_icache_axi_wrapper
   ) i_cva6_icache (
       .clk_i         (clk_i),
       .rst_ni        (rst_ni),
+      .clear_i       (clear_i),
       .flush_i       (flush_i),
       .en_i          (en_i),
       .miss_o        (miss_o),
@@ -139,6 +141,7 @@ module cva6_icache_axi_wrapper
   ) i_axi_shim (
       .clk_i      (clk_i),
       .rst_ni     (rst_ni),
+      .clear_i    (clear_i),
       .rd_req_i   (axi_rd_req),
       .rd_gnt_o   (axi_rd_gnt),
       .rd_addr_i  (axi_rd_addr),
@@ -193,9 +196,9 @@ module cva6_icache_axi_wrapper
   end
 
   // Registers
-  `FFARNC(req_valid_q , req_valid_d, 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(req_data_q  , req_data_d , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(first_q     , first_d    , 1'b0, 1'b0, clk_i, rst_ni)
-  `FFARNC(rd_shift_q  , rd_shift_d , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(req_valid_q, req_valid_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(req_data_q, req_data_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(first_q, first_d, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(rd_shift_q, rd_shift_d, clear_i, '0, clk_i, rst_ni)
 
 endmodule  // cva6_icache_axi_wrapper

--- a/core/cache_subsystem/cva6_icache_axi_wrapper.sv
+++ b/core/cache_subsystem/cva6_icache_axi_wrapper.sv
@@ -13,6 +13,8 @@
 // Description: wrapper module to connect the L1I$ to a 64bit AXI bus.
 //
 
+`include "common_cells/registers.svh"
+
 module cva6_icache_axi_wrapper
   import ariane_pkg::*;
   import wt_cache_pkg::*;
@@ -191,18 +193,9 @@ module cva6_icache_axi_wrapper
   end
 
   // Registers
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_rd_buf
-    if (!rst_ni) begin
-      req_valid_q <= 1'b0;
-      req_data_q  <= '0;
-      first_q     <= 1'b1;
-      rd_shift_q  <= '0;
-    end else begin
-      req_valid_q <= req_valid_d;
-      req_data_q  <= req_data_d;
-      first_q     <= first_d;
-      rd_shift_q  <= rd_shift_d;
-    end
-  end
+  `FFARNC(req_valid_q , req_valid_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(req_data_q  , req_data_d , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(first_q     , first_d    , 1'b0, 1'b0, clk_i, rst_ni)
+  `FFARNC(rd_shift_q  , rd_shift_d , 1'b0, '0  , clk_i, rst_ni)
 
 endmodule  // cva6_icache_axi_wrapper

--- a/core/cache_subsystem/cva6_icache_axi_wrapper.sv
+++ b/core/cache_subsystem/cva6_icache_axi_wrapper.sv
@@ -198,7 +198,7 @@ module cva6_icache_axi_wrapper
   // Registers
   `FFARNC(req_valid_q, req_valid_d, clear_i, '0, clk_i, rst_ni)
   `FFARNC(req_data_q, req_data_d, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(first_q, first_d, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(first_q, first_d, clear_i, 1'b1, clk_i, rst_ni)
   `FFARNC(rd_shift_q, rd_shift_d, clear_i, '0, clk_i, rst_ni)
 
 endmodule  // cva6_icache_axi_wrapper

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -29,6 +29,7 @@ module miss_handler
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     output logic busy_o,  // miss handler or axi is busy
     input logic flush_i,  // flush request
     output logic flush_ack_o,  // acknowledge successful flush
@@ -507,12 +508,12 @@ module miss_handler
   // --------------------
   // Sequential Process
   // --------------------
-  `FFARNC(mshr_q, mshr_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(state_q, state_d, 1'b0, INIT, clk_i, rst_ni)
-  `FFARNC(cnt_q, cnt_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(evict_way_q, evict_way_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(evict_cl_q, evict_cl_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(serve_amo_q, serve_amo_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(mshr_q, mshr_d, clear_i '0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, INIT, clk_i, rst_ni)
+  `FFARNC(cnt_q, cnt_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(evict_way_q, evict_way_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(evict_cl_q, evict_cl_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(serve_amo_q, serve_amo_d, clear_i, '0, clk_i, rst_ni)
 
   //pragma translate_off
 `ifndef VERILATOR
@@ -561,6 +562,7 @@ module miss_handler
   ) i_bypass_arbiter (
       .clk_i (clk_i),
       .rst_ni(rst_ni),
+      .clear_i(clear_i),
       // Master Side
       .req_i (bypass_ports_req),
       .rsp_o (bypass_ports_rsp),
@@ -585,6 +587,7 @@ module miss_handler
   ) i_bypass_axi_adapter (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
+      .clear_i(clear_i),
       .busy_o(bypass_axi_busy),
       .req_i(bypass_adapter_req.req),
       .type_i(bypass_adapter_req.reqtype),
@@ -621,6 +624,7 @@ module miss_handler
   ) i_miss_axi_adapter (
       .clk_i,
       .rst_ni,
+      .clear_i,
       .busy_o               (miss_axi_busy),
       .req_i                (req_fsm_miss_valid),
       .type_i               (req_fsm_miss_req),
@@ -687,6 +691,7 @@ module axi_adapter_arbiter #(
 ) (
     input  logic                clk_i,   // Clock
     input  logic                rst_ni,  // Asynchronous reset active low
+    input  logic                clear_i,
     // Master ports
     input  req_t [NR_PORTS-1:0] req_i,
     output rsp_t [NR_PORTS-1:0] rsp_o,
@@ -789,10 +794,10 @@ module axi_adapter_arbiter #(
     endcase
   end
 
-  `FFARNC(state_q, state_d, 1'b0, IDLE, clk_i, rst_ni)
-  `FFARNC(sel_q, sel_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(req_q, req_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(outstanding_cnt_q, outstanding_cnt_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(sel_q, sel_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(req_q, req_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(outstanding_cnt_q, outstanding_cnt_d, clear_i, '0, clk_i, rst_ni)
 
   // ------------
   // Assertions

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -507,12 +507,12 @@ module miss_handler
   // --------------------
   // Sequential Process
   // --------------------
-  `FFARNC(mshr_q      , mshr_d     , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(state_q     , state_d    , 1'b0, INIT, clk_i, rst_ni)
-  `FFARNC(cnt_q       , cnt_d      , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(evict_way_q , evict_way_d, 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(evict_cl_q  , evict_cl_d , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(serve_amo_q , serve_amo_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(mshr_q, mshr_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, 1'b0, INIT, clk_i, rst_ni)
+  `FFARNC(cnt_q, cnt_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(evict_way_q, evict_way_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(evict_cl_q, evict_cl_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(serve_amo_q, serve_amo_d, 1'b0, '0, clk_i, rst_ni)
 
   //pragma translate_off
 `ifndef VERILATOR
@@ -789,10 +789,10 @@ module axi_adapter_arbiter #(
     endcase
   end
 
-  `FFARNC(state_q           , state_d          , 1'b0, IDLE, clk_i, rst_ni)
-  `FFARNC(sel_q             , sel_d            , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(req_q             , req_d            , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(outstanding_cnt_q , outstanding_cnt_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(state_q, state_d, 1'b0, IDLE, clk_i, rst_ni)
+  `FFARNC(sel_q, sel_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(req_q, req_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(outstanding_cnt_q, outstanding_cnt_d, 1'b0, '0, clk_i, rst_ni)
 
   // ------------
   // Assertions

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -560,15 +560,15 @@ module miss_handler
       .req_t              (bypass_req_t),
       .rsp_t              (bypass_rsp_t)
   ) i_bypass_arbiter (
-      .clk_i(clk_i),
-      .rst_ni(rst_ni),
+      .clk_i  (clk_i),
+      .rst_ni (rst_ni),
       .clear_i(clear_i),
       // Master Side
-      .req_i (bypass_ports_req),
-      .rsp_o (bypass_ports_rsp),
+      .req_i  (bypass_ports_req),
+      .rsp_o  (bypass_ports_rsp),
       // Slave Side
-      .req_o (bypass_adapter_req),
-      .rsp_i (bypass_adapter_rsp)
+      .req_o  (bypass_adapter_req),
+      .rsp_i  (bypass_adapter_rsp)
   );
 
   // ----------------------

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -508,7 +508,7 @@ module miss_handler
   // --------------------
   // Sequential Process
   // --------------------
-  `FFARNC(mshr_q, mshr_d, clear_i '0, clk_i, rst_ni)
+  `FFARNC(mshr_q, mshr_d, clear_i, '0, clk_i, rst_ni)
   `FFARNC(state_q, state_d, clear_i, INIT, clk_i, rst_ni)
   `FFARNC(cnt_q, cnt_d, clear_i, '0, clk_i, rst_ni)
   `FFARNC(evict_way_q, evict_way_d, clear_i, '0, clk_i, rst_ni)

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -16,6 +16,8 @@
 // MISS Handler
 // --------------
 
+`include "common_cells/registers.svh"
+
 module miss_handler
   import ariane_pkg::*;
   import std_cache_pkg::*;
@@ -505,23 +507,12 @@ module miss_handler
   // --------------------
   // Sequential Process
   // --------------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      mshr_q      <= '0;
-      state_q     <= INIT;
-      cnt_q       <= '0;
-      evict_way_q <= '0;
-      evict_cl_q  <= '0;
-      serve_amo_q <= 1'b0;
-    end else begin
-      mshr_q      <= mshr_d;
-      state_q     <= state_d;
-      cnt_q       <= cnt_d;
-      evict_way_q <= evict_way_d;
-      evict_cl_q  <= evict_cl_d;
-      serve_amo_q <= serve_amo_d;
-    end
-  end
+  `FFARNC(mshr_q      , mshr_d     , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(state_q     , state_d    , 1'b0, INIT, clk_i, rst_ni)
+  `FFARNC(cnt_q       , cnt_d      , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(evict_way_q , evict_way_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(evict_cl_q  , evict_cl_d , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(serve_amo_q , serve_amo_d, 1'b0, '0  , clk_i, rst_ni)
 
   //pragma translate_off
 `ifndef VERILATOR
@@ -798,19 +789,11 @@ module axi_adapter_arbiter #(
     endcase
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      state_q           <= IDLE;
-      sel_q             <= '0;
-      req_q             <= '0;
-      outstanding_cnt_q <= '0;
-    end else begin
-      state_q           <= state_d;
-      sel_q             <= sel_d;
-      req_q             <= req_d;
-      outstanding_cnt_q <= outstanding_cnt_d;
-    end
-  end
+  `FFARNC(state_q           , state_d          , 1'b0, IDLE, clk_i, rst_ni)
+  `FFARNC(sel_q             , sel_d            , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(req_q             , req_d            , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(outstanding_cnt_q , outstanding_cnt_d, 1'b0, '0  , clk_i, rst_ni)
+
   // ------------
   // Assertions
   // ------------

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -560,7 +560,7 @@ module miss_handler
       .req_t              (bypass_req_t),
       .rsp_t              (bypass_rsp_t)
   ) i_bypass_arbiter (
-      .clk_i (clk_i),
+      .clk_i(clk_i),
       .rst_ni(rst_ni),
       .clear_i(clear_i),
       // Master Side
@@ -689,7 +689,7 @@ module axi_adapter_arbiter #(
     parameter type req_t = std_cache_pkg::bypass_req_t,
     parameter type rsp_t = std_cache_pkg::bypass_rsp_t
 ) (
-    input  logic                clk_i,   // Clock
+    input  logic                clk_i,  // Clock
     input  logic                rst_ni,  // Asynchronous reset active low
     input  logic                clear_i,
     // Master ports

--- a/core/cache_subsystem/miss_handler.sv
+++ b/core/cache_subsystem/miss_handler.sv
@@ -689,8 +689,8 @@ module axi_adapter_arbiter #(
     parameter type req_t = std_cache_pkg::bypass_req_t,
     parameter type rsp_t = std_cache_pkg::bypass_rsp_t
 ) (
-    input  logic                clk_i,  // Clock
-    input  logic                rst_ni,  // Asynchronous reset active low
+    input  logic                clk_i,
+    input  logic                rst_ni,
     input  logic                clear_i,
     // Master ports
     input  req_t [NR_PORTS-1:0] req_i,

--- a/core/cache_subsystem/std_cache_subsystem.sv
+++ b/core/cache_subsystem/std_cache_subsystem.sv
@@ -29,6 +29,7 @@ module std_cache_subsystem
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     input riscv::priv_lvl_t priv_lvl_i,
     output logic busy_o,
     input logic stall_i,  // stall new memory requests
@@ -82,6 +83,7 @@ module std_cache_subsystem
   ) i_cva6_icache_axi_wrapper (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
+      .clear_i   (clear_i),
       .priv_lvl_i(priv_lvl_i),
       .flush_i   (icache_flush_i),
       .en_i      (icache_en_i),
@@ -110,6 +112,7 @@ module std_cache_subsystem
   ) i_nbdcache (
       .clk_i,
       .rst_ni,
+      .clear_i     (clear_i),
       .enable_i    (dcache_enable_i),
       .flush_i     (dcache_flush_i),
       .flush_ack_o (dcache_flush_ack_o),

--- a/core/cache_subsystem/std_nbdcache.sv
+++ b/core/cache_subsystem/std_nbdcache.sv
@@ -24,6 +24,7 @@ module std_nbdcache
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,  // Synchronous clear active high
     // Cache management
     input logic enable_i,  // from CSR
     input logic flush_i,  // high until acknowledged

--- a/core/cache_subsystem/tag_cmp.sv
+++ b/core/cache_subsystem/tag_cmp.sv
@@ -28,6 +28,7 @@ module tag_cmp #(
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
 
     input logic [NR_PORTS-1:0][DCACHE_SET_ASSOC-1:0] req_i,
     output logic [NR_PORTS-1:0] gnt_o,
@@ -98,6 +99,6 @@ module tag_cmp #(
 `endif
   end
 
-  `FFARNC(id_q, id_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(id_q, id_d, clear_i, '0, clk_i, rst_ni)
 
 endmodule

--- a/core/cache_subsystem/tag_cmp.sv
+++ b/core/cache_subsystem/tag_cmp.sv
@@ -15,6 +15,9 @@
 // Description: Arbitrates access to cache memories, simplified request grant protocol
 //              checks for hit or miss on cache
 //
+
+`include "common_cells/registers.svh"
+
 module tag_cmp #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg          = config_pkg::cva6_cfg_empty,
     parameter int unsigned           NR_PORTS         = 3,
@@ -95,12 +98,6 @@ module tag_cmp #(
 `endif
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      id_q <= 0;
-    end else begin
-      id_q <= id_d;
-    end
-  end
+  `FFARNC(id_q, id_d, 1'b0, '0, clk_i, rst_ni)
 
 endmodule

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -13,6 +13,7 @@
 // Description: adapter module to connect the L1D$ and L1I$ to a 64bit AXI bus.
 //
 
+`include "common_cells/registers.svh"
 
 module wt_axi_adapter
   import ariane_pkg::*;
@@ -619,39 +620,20 @@ module wt_axi_adapter
   // assign dcache_rtrn_o.inv.vld  = '0;
   // assign dcache_rtrn_o.inv.all  = '0;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_rd_buf
-    if (!rst_ni) begin
-      icache_first_q         <= 1'b1;
-      dcache_first_q         <= 1'b1;
-      icache_rd_shift_q      <= '0;
-      icache_rd_shift_user_q <= '0;
-      dcache_rd_shift_q      <= '0;
-      dcache_rd_shift_user_q <= '0;
-      icache_rtrn_vld_q      <= '0;
-      dcache_rtrn_vld_q      <= '0;
-      icache_rtrn_tid_q      <= '0;
-      dcache_rtrn_tid_q      <= '0;
-      dcache_rtrn_type_q     <= wt_cache_pkg::DCACHE_LOAD_ACK;
-      dcache_rtrn_inv_q      <= '0;
-      amo_off_q              <= '0;
-      amo_gen_r_q            <= 1'b0;
-    end else begin
-      icache_first_q         <= icache_first_d;
-      dcache_first_q         <= dcache_first_d;
-      icache_rd_shift_q      <= icache_rd_shift_d;
-      icache_rd_shift_user_q <= icache_rd_shift_user_d;
-      dcache_rd_shift_q      <= dcache_rd_shift_d;
-      dcache_rd_shift_user_q <= dcache_rd_shift_user_d;
-      icache_rtrn_vld_q      <= icache_rtrn_vld_d;
-      dcache_rtrn_vld_q      <= dcache_rtrn_vld_d;
-      icache_rtrn_tid_q      <= icache_rtrn_tid_d;
-      dcache_rtrn_tid_q      <= dcache_rtrn_tid_d;
-      dcache_rtrn_type_q     <= dcache_rtrn_type_d;
-      dcache_rtrn_inv_q      <= dcache_rtrn_inv_d;
-      amo_off_q              <= amo_off_d;
-      amo_gen_r_q            <= amo_gen_r_d;
-    end
-  end
+  `FFARNC(icache_first_q         , icache_first_d        , 1'b0, 1'b1                         , clk_i, rst_ni)
+  `FFARNC(dcache_first_q         , dcache_first_d        , 1'b0, 1'b1                         , clk_i, rst_ni)
+  `FFARNC(icache_rd_shift_q      , icache_rd_shift_d     , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_rd_shift_user_q , icache_rd_shift_user_d, 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rd_shift_q      , dcache_rd_shift_d     , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rd_shift_user_q , dcache_rd_shift_user_d, 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_rtrn_vld_q      , icache_rtrn_vld_d     , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_vld_q      , dcache_rtrn_vld_d     , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_rtrn_tid_q      , icache_rtrn_tid_d     , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_tid_q      , dcache_rtrn_tid_d     , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_type_q     , dcache_rtrn_type_d    , 1'b0, wt_cache_pkg::DCACHE_LOAD_ACK, clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_inv_q      , dcache_rtrn_inv_d     , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(amo_off_q              , amo_off_d             , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(amo_gen_r_q            , amo_gen_r_d           , 1'b0, '0                           , clk_i, rst_ni)
 
 
   ///////////////////////////////////////////////////////

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -61,6 +61,7 @@ module wt_axi_adapter
   localparam MaxNumWords = $clog2(CVA6Cfg.AxiDataWidth / 8);
   localparam AxiRdBlenIcache = ariane_pkg::ICACHE_LINE_WIDTH / CVA6Cfg.AxiDataWidth - 1;
   localparam AxiRdBlenDcache = ariane_pkg::DCACHE_LINE_WIDTH / CVA6Cfg.AxiDataWidth - 1;
+  localparam DcacheReturnTypeRstVal = wt_cache_pkg::DCACHE_LOAD_ACK;
 
   ///////////////////////////////////////////////////////
   // request path
@@ -621,20 +622,20 @@ module wt_axi_adapter
   // assign dcache_rtrn_o.inv.vld  = '0;
   // assign dcache_rtrn_o.inv.all  = '0;
 
-  `FFARNC(icache_first_q         , icache_first_d        , clear_i, 1'b1                         , clk_i, rst_ni)
-  `FFARNC(dcache_first_q         , dcache_first_d        , clear_i, 1'b1                         , clk_i, rst_ni)
-  `FFARNC(icache_rd_shift_q      , icache_rd_shift_d     , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(icache_rd_shift_user_q , icache_rd_shift_user_d, clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rd_shift_q      , dcache_rd_shift_d     , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rd_shift_user_q , dcache_rd_shift_user_d, clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(icache_rtrn_vld_q      , icache_rtrn_vld_d     , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_vld_q      , dcache_rtrn_vld_d     , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(icache_rtrn_tid_q      , icache_rtrn_tid_d     , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_tid_q      , dcache_rtrn_tid_d     , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_type_q     , dcache_rtrn_type_d    , clear_i, wt_cache_pkg::DCACHE_LOAD_ACK, clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_inv_q      , dcache_rtrn_inv_d     , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(amo_off_q              , amo_off_d             , clear_i, '0                           , clk_i, rst_ni)
-  `FFARNC(amo_gen_r_q            , amo_gen_r_d           , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_first_q, icache_first_d, clear_i, 1'b1, clk_i, rst_ni)
+  `FFARNC(dcache_first_q, dcache_first_d, clear_i, 1'b1, clk_i, rst_ni)
+  `FFARNC(icache_rd_shift_q, icache_rd_shift_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(icache_rd_shift_user_q, icache_rd_shift_user_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dcache_rd_shift_q, dcache_rd_shift_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dcache_rd_shift_user_q, dcache_rd_shift_user_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(icache_rtrn_vld_q, icache_rtrn_vld_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_vld_q, dcache_rtrn_vld_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(icache_rtrn_tid_q, icache_rtrn_tid_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_tid_q, dcache_rtrn_tid_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_type_q, dcache_rtrn_type_d, clear_i, DcacheReturnTypeRstVal, clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_inv_q, dcache_rtrn_inv_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(amo_off_q, amo_off_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(amo_gen_r_q, amo_gen_r_d, clear_i, '0, clk_i, rst_ni)
 
 
   ///////////////////////////////////////////////////////

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -27,6 +27,7 @@ module wt_axi_adapter
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
 
     // icache
     input  logic         icache_data_req_i,
@@ -119,7 +120,7 @@ module wt_axi_adapter
   ) i_rr_arb_tree (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .flush_i('0),
+      .flush_i(clear_i),
       .rr_i   ('0),
       .req_i  (arb_req),
       .gnt_o  (arb_ack),
@@ -312,7 +313,7 @@ module wt_axi_adapter
   ) i_icache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
-      .flush_i   (1'b0),
+      .flush_i   (clear_i),
       .testmode_i(1'b0),
       .full_o    (icache_data_full),
       .empty_o   (icache_data_empty),
@@ -329,7 +330,7 @@ module wt_axi_adapter
   ) i_dcache_data_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
-      .flush_i   (1'b0),
+      .flush_i   (clear_i),
       .testmode_i(1'b0),
       .full_o    (dcache_data_full),
       .empty_o   (dcache_data_empty),
@@ -353,7 +354,7 @@ module wt_axi_adapter
   ) i_rd_icache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
-      .flush_i   (1'b0),
+      .flush_i   (clear_i),
       .testmode_i(1'b0),
       .full_o    (icache_rd_full),
       .empty_o   (icache_rd_empty),
@@ -370,7 +371,7 @@ module wt_axi_adapter
   ) i_rd_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
-      .flush_i   (1'b0),
+      .flush_i   (clear_i),
       .testmode_i(1'b0),
       .full_o    (dcache_rd_full),
       .empty_o   (dcache_rd_empty),
@@ -387,7 +388,7 @@ module wt_axi_adapter
   ) i_wr_dcache_id (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
-      .flush_i   (1'b0),
+      .flush_i   (clear_i),
       .testmode_i(1'b0),
       .full_o    (dcache_wr_full),
       .empty_o   (dcache_wr_empty),
@@ -417,7 +418,7 @@ module wt_axi_adapter
   ) i_b_fifo (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
-      .flush_i   (1'b0),
+      .flush_i   (clear_i),
       .testmode_i(1'b0),
       .full_o    (b_full),
       .empty_o   (b_empty),
@@ -620,20 +621,20 @@ module wt_axi_adapter
   // assign dcache_rtrn_o.inv.vld  = '0;
   // assign dcache_rtrn_o.inv.all  = '0;
 
-  `FFARNC(icache_first_q         , icache_first_d        , 1'b0, 1'b1                         , clk_i, rst_ni)
-  `FFARNC(dcache_first_q         , dcache_first_d        , 1'b0, 1'b1                         , clk_i, rst_ni)
-  `FFARNC(icache_rd_shift_q      , icache_rd_shift_d     , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(icache_rd_shift_user_q , icache_rd_shift_user_d, 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rd_shift_q      , dcache_rd_shift_d     , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rd_shift_user_q , dcache_rd_shift_user_d, 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(icache_rtrn_vld_q      , icache_rtrn_vld_d     , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_vld_q      , dcache_rtrn_vld_d     , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(icache_rtrn_tid_q      , icache_rtrn_tid_d     , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_tid_q      , dcache_rtrn_tid_d     , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_type_q     , dcache_rtrn_type_d    , 1'b0, wt_cache_pkg::DCACHE_LOAD_ACK, clk_i, rst_ni)
-  `FFARNC(dcache_rtrn_inv_q      , dcache_rtrn_inv_d     , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(amo_off_q              , amo_off_d             , 1'b0, '0                           , clk_i, rst_ni)
-  `FFARNC(amo_gen_r_q            , amo_gen_r_d           , 1'b0, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_first_q         , icache_first_d        , clear_i, 1'b1                         , clk_i, rst_ni)
+  `FFARNC(dcache_first_q         , dcache_first_d        , clear_i, 1'b1                         , clk_i, rst_ni)
+  `FFARNC(icache_rd_shift_q      , icache_rd_shift_d     , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_rd_shift_user_q , icache_rd_shift_user_d, clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rd_shift_q      , dcache_rd_shift_d     , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rd_shift_user_q , dcache_rd_shift_user_d, clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_rtrn_vld_q      , icache_rtrn_vld_d     , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_vld_q      , dcache_rtrn_vld_d     , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(icache_rtrn_tid_q      , icache_rtrn_tid_d     , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_tid_q      , dcache_rtrn_tid_d     , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_type_q     , dcache_rtrn_type_d    , clear_i, wt_cache_pkg::DCACHE_LOAD_ACK, clk_i, rst_ni)
+  `FFARNC(dcache_rtrn_inv_q      , dcache_rtrn_inv_d     , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(amo_off_q              , amo_off_d             , clear_i, '0                           , clk_i, rst_ni)
+  `FFARNC(amo_gen_r_q            , amo_gen_r_d           , clear_i, '0                           , clk_i, rst_ni)
 
 
   ///////////////////////////////////////////////////////
@@ -648,6 +649,7 @@ module wt_axi_adapter
   ) i_axi_shim (
       .clk_i      (clk_i),
       .rst_ni     (rst_ni),
+      .clear_i    (clear_i),
       .rd_req_i   (axi_rd_req),
       .rd_gnt_o   (axi_rd_gnt),
       .rd_addr_i  (axi_rd_addr),

--- a/core/cache_subsystem/wt_axi_adapter.sv
+++ b/core/cache_subsystem/wt_axi_adapter.sv
@@ -61,7 +61,7 @@ module wt_axi_adapter
   localparam MaxNumWords = $clog2(CVA6Cfg.AxiDataWidth / 8);
   localparam AxiRdBlenIcache = ariane_pkg::ICACHE_LINE_WIDTH / CVA6Cfg.AxiDataWidth - 1;
   localparam AxiRdBlenDcache = ariane_pkg::DCACHE_LINE_WIDTH / CVA6Cfg.AxiDataWidth - 1;
-  localparam DcacheReturnTypeRstVal = wt_cache_pkg::DCACHE_LOAD_ACK;
+  localparam dcache_in_t DcacheReturnTypeRstVal = wt_cache_pkg::DCACHE_LOAD_ACK;
 
   ///////////////////////////////////////////////////////
   // request path

--- a/core/cache_subsystem/wt_cache_subsystem.sv
+++ b/core/cache_subsystem/wt_cache_subsystem.sv
@@ -178,6 +178,7 @@ module wt_cache_subsystem
   ) i_adapter (
       .clk_i            (clk_i),
       .rst_ni           (rst_ni),
+      .clear_i          (clear_i),
       .icache_data_req_i(icache_adapter_data_req),
       .icache_data_ack_o(adapter_icache_data_ack),
       .icache_data_i    (icache_adapter),

--- a/core/cache_subsystem/wt_cache_subsystem.sv
+++ b/core/cache_subsystem/wt_cache_subsystem.sv
@@ -30,6 +30,7 @@ module wt_cache_subsystem
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     output logic busy_o,
     input logic stall_i,  // stall new memory requests
     input logic init_ni,
@@ -91,6 +92,7 @@ module wt_cache_subsystem
   ) i_cva6_icache (
       .clk_i         (clk_i),
       .rst_ni        (rst_ni),
+      .clear_i       (clear_i),
       .flush_i       (icache_flush_i),
       .en_i          (icache_en_i),
       .miss_o        (icache_miss_o),
@@ -121,6 +123,7 @@ module wt_cache_subsystem
   ) i_wt_dcache (
       .clk_i           (clk_i),
       .rst_ni          (rst_ni),
+      .clear_i         (clear_i),
       .enable_i        (dcache_enable_i),
       .busy_o          (dcache_busy),
       .stall_i         (stall_i),

--- a/core/cache_subsystem/wt_dcache.sv
+++ b/core/cache_subsystem/wt_dcache.sv
@@ -24,9 +24,8 @@ module wt_dcache
     parameter logic [CACHE_ID_WIDTH-1:0] RdAmoTxId = 1
 ) (
     input logic clk_i,  // Clock
-    input logic rst_ni, // Asynchronous reset active low
-    input logic clear_i, // Synchronous clear active high
-
+    input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,  // Synchronous clear active high
     // Cache management
     input logic enable_i,  // from CSR
     input logic flush_i,  // high until acknowledged

--- a/core/cache_subsystem/wt_dcache.sv
+++ b/core/cache_subsystem/wt_dcache.sv
@@ -25,6 +25,7 @@ module wt_dcache
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni, // Asynchronous reset active low
+    input logic clear_i, // Synchronous clear active high
 
     // Cache management
     input logic enable_i,  // from CSR
@@ -129,6 +130,7 @@ module wt_dcache
   ) i_wt_dcache_missunit (
       .clk_i          (clk_i),
       .rst_ni         (rst_ni),
+      .clear_i        (clear_i),
       .enable_i       (enable_i),
       .flush_i        (flush_i),
       .flush_ack_o    (flush_ack_o),
@@ -191,6 +193,7 @@ module wt_dcache
       ) i_wt_dcache_ctrl (
           .clk_i          (clk_i),
           .rst_ni         (rst_ni),
+          .clear_i        (clear_i),
           .cache_en_i     (cache_en),
           .busy_o         (ctrl_busy[k]),
           .stall_i        (stall_i),
@@ -256,6 +259,7 @@ module wt_dcache
   ) i_wt_dcache_wbuffer (
       .clk_i          (clk_i),
       .rst_ni         (rst_ni),
+      .clear_i        (clear_i),
       .empty_o        (wbuffer_empty_o),
       .not_ni_o       (wbuffer_not_ni_o),
       // TODO: fix this
@@ -314,6 +318,7 @@ module wt_dcache
   ) i_wt_dcache_mem (
       .clk_i          (clk_i),
       .rst_ni         (rst_ni),
+      .clear_i        (clear_i),
       // read ports
       .rd_prio_i      (rd_prio),
       .rd_tag_i       (rd_tag),

--- a/core/cache_subsystem/wt_dcache_ctrl.sv
+++ b/core/cache_subsystem/wt_dcache_ctrl.sv
@@ -12,6 +12,7 @@
 // Date: 13.09.2018
 // Description: DCache controller for read port
 
+`include "common_cells/registers.svh"
 
 module wt_dcache_ctrl
   import ariane_pkg::*;
@@ -253,30 +254,15 @@ module wt_dcache_ctrl
   ///////////////////////////////////////////////////////
   // ff's
   ///////////////////////////////////////////////////////
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
-    if (!rst_ni) begin
-      state_q       <= IDLE;
-      address_tag_q <= '0;
-      address_idx_q <= '0;
-      address_off_q <= '0;
-      id_q          <= '0;
-      vld_data_q    <= '0;
-      data_size_q   <= '0;
-      rd_req_q      <= '0;
-      rd_ack_q      <= '0;
-    end else begin
-      state_q       <= state_d;
-      address_tag_q <= address_tag_d;
-      address_idx_q <= address_idx_d;
-      address_off_q <= address_off_d;
-      id_q          <= id_d;
-      vld_data_q    <= vld_data_d;
-      data_size_q   <= data_size_d;
-      rd_req_q      <= rd_req_d;
-      rd_ack_q      <= rd_ack_d;
-    end
-  end
+  `FFARNC(state_q       , state_d      , 1'b0, IDLE, clk_i, rst_ni)
+  `FFARNC(address_tag_q , address_tag_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(address_idx_q , address_idx_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(address_off_q , address_off_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(id_q          , id_d         , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(vld_data_q    , vld_data_d   , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(data_size_q   , data_size_d  , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(rd_req_q      , rd_req_d     , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(rd_ack_q      , rd_ack_d     , 1'b0, '0  , clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/cache_subsystem/wt_dcache_ctrl.sv
+++ b/core/cache_subsystem/wt_dcache_ctrl.sv
@@ -23,6 +23,7 @@ module wt_dcache_ctrl
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,  // Synchronous clear active high
     input logic cache_en_i,
     output logic busy_o,
     input logic stall_i,  // stall new memory requests
@@ -254,15 +255,15 @@ module wt_dcache_ctrl
   ///////////////////////////////////////////////////////
   // ff's
   ///////////////////////////////////////////////////////
-  `FFARNC(state_q       , state_d      , 1'b0, IDLE, clk_i, rst_ni)
-  `FFARNC(address_tag_q , address_tag_d, 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(address_idx_q , address_idx_d, 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(address_off_q , address_off_d, 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(id_q          , id_d         , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(vld_data_q    , vld_data_d   , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(data_size_q   , data_size_d  , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(rd_req_q      , rd_req_d     , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(rd_ack_q      , rd_ack_d     , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(address_tag_q, address_tag_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(address_idx_q, address_idx_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(address_off_q, address_off_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(id_q, id_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vld_data_q, vld_data_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(data_size_q, data_size_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(rd_req_q, rd_req_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(rd_ack_q, rd_ack_d, clear_i, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -170,7 +170,7 @@ module wt_dcache_mem
   ) i_rr_arb_tree (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .flush_i('0),
+      .flush_i(clear_i),
       .rr_i   ('0),
       .req_i  (rd_req_masked),
       .gnt_o  (rd_ack_o),
@@ -342,10 +342,10 @@ module wt_dcache_mem
     );
   end
 
-  `FFARNC(bank_idx_q, bank_idx_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(bank_off_q, bank_off_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(vld_sel_q, vld_sel_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(cmp_en_q, cmp_en_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(bank_idx_q, bank_idx_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(bank_off_q, bank_off_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vld_sel_q, vld_sel_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(cmp_en_q, cmp_en_d, clear_i, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -342,10 +342,10 @@ module wt_dcache_mem
     );
   end
 
-  `FFARNC(bank_idx_q , bank_idx_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(bank_off_q , bank_off_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(vld_sel_q  , vld_sel_d , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(cmp_en_q   , cmp_en_d  , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(bank_idx_q, bank_idx_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(bank_off_q, bank_off_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(vld_sel_q, vld_sel_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(cmp_en_q, cmp_en_d, 1'b0, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions
@@ -395,8 +395,8 @@ module wt_dcache_mem
   logic [ariane_pkg::DCACHE_SET_ASSOC-1:0] load_enable;
   for (genvar i = 0; i < ariane_pkg::DCACHE_SET_ASSOC; i++) begin : gen_p_mirror_registers
     assign load_enable[i] = (vld_req[i] & vld_we) ? 1'b1 : 1'b0;
-    `FFLARNC(vld_mirror[vld_addr][i], vld_wdata[i], load_enable[i], clear_i, '{default: '0}, clk_i, rst_ni)
-    `FFLARNC(tag_mirror[vld_addr][i], wr_cl_tag_i, load_enable[i], clear_i, '{default: '0}, clk_i, rst_ni)
+    `FFLARNC(vld_mirror[vld_addr][i], vld_wdata[i], load_enable[i], clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(tag_mirror[vld_addr][i], wr_cl_tag_i, load_enable[i], clear_i, '0, clk_i, rst_ni)
   end
 
   for (genvar i = 0; i < DCACHE_SET_ASSOC; i++) begin : gen_tag_dubl_test

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -36,6 +36,7 @@ module wt_dcache_mem
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
 
     // ports
     input logic [NumPorts-1:0][DCACHE_TAG_WIDTH-1:0] rd_tag_i,  // tag in - comes one cycle later
@@ -396,17 +397,17 @@ module wt_dcache_mem
       vld_mirror <= '{default: '0};
       tag_mirror <= '{default: '0};
     end else begin
-      // if (clear_i) begin
-      //   vld_mirror <= '{default: '0};
-      //   tag_mirror <= '{default: '0};
-      // end else begin
+      if (clear_i) begin
+        vld_mirror <= '{default: '0};
+        tag_mirror <= '{default: '0};
+      end else begin
         for (int i = 0; i < DCACHE_SET_ASSOC; i++) begin
           if (vld_req[i] & vld_we) begin
             vld_mirror[vld_addr][i] <= vld_wdata[i];
             tag_mirror[vld_addr][i] <= wr_cl_tag_i;
           end
         end
-      // end
+      end
     end
   end
 

--- a/core/cache_subsystem/wt_dcache_mem.sv
+++ b/core/cache_subsystem/wt_dcache_mem.sv
@@ -25,6 +25,7 @@
 //        4) Read ports with same priority are RR arbited. but high prio ports (rd_prio_i[port_nr] = '1b1) will stall
 //           low prio ports (rd_prio_i[port_nr] = '1b0)
 
+`include "common_cells/registers.svh"
 
 module wt_dcache_mem
   import ariane_pkg::*;
@@ -340,19 +341,10 @@ module wt_dcache_mem
     );
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
-    if (!rst_ni) begin
-      bank_idx_q <= '0;
-      bank_off_q <= '0;
-      vld_sel_q  <= '0;
-      cmp_en_q   <= '0;
-    end else begin
-      bank_idx_q <= bank_idx_d;
-      bank_off_q <= bank_off_d;
-      vld_sel_q  <= vld_sel_d;
-      cmp_en_q   <= cmp_en_d;
-    end
-  end
+  `FFARNC(bank_idx_q , bank_idx_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(bank_off_q , bank_off_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(vld_sel_q  , vld_sel_d , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(cmp_en_q   , cmp_en_d  , 1'b0, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions
@@ -404,12 +396,17 @@ module wt_dcache_mem
       vld_mirror <= '{default: '0};
       tag_mirror <= '{default: '0};
     end else begin
-      for (int i = 0; i < DCACHE_SET_ASSOC; i++) begin
-        if (vld_req[i] & vld_we) begin
-          vld_mirror[vld_addr][i] <= vld_wdata[i];
-          tag_mirror[vld_addr][i] <= wr_cl_tag_i;
+      // if (clear_i) begin
+      //   vld_mirror <= '{default: '0};
+      //   tag_mirror <= '{default: '0};
+      // end else begin
+        for (int i = 0; i < DCACHE_SET_ASSOC; i++) begin
+          if (vld_req[i] & vld_we) begin
+            vld_mirror[vld_addr][i] <= vld_wdata[i];
+            tag_mirror[vld_addr][i] <= wr_cl_tag_i;
+          end
         end
-      end
+      // end
     end
   end
 

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -13,6 +13,7 @@
 // Description: miss controller for WT dcache. Note that the current assumption
 // is that the port with the highest index issues writes instead of reads.
 
+`include "common_cells/registers.svh"
 
 module wt_dcache_missunit
   import ariane_pkg::*;
@@ -592,33 +593,17 @@ module wt_dcache_missunit
   // ff's
   ///////////////////////////////////////////////////////
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
-    if (!rst_ni) begin
-      state_q               <= INIT;
-      cnt_q                 <= '0;
-      enable_q              <= '0;
-      flush_ack_q           <= '0;
-      mshr_vld_q            <= '0;
-      mshr_vld_q1           <= '0;
-      mshr_q                <= '0;
-      mshr_rdrd_collision_q <= '0;
-      miss_req_masked_q     <= '0;
-      amo_req_q             <= '0;
-      stores_inflight_q     <= '0;
-    end else begin
-      state_q               <= state_d;
-      cnt_q                 <= cnt_d;
-      enable_q              <= enable_d;
-      flush_ack_q           <= flush_ack_d;
-      mshr_vld_q            <= mshr_vld_d;
-      mshr_vld_q1           <= mshr_vld_q;
-      mshr_q                <= mshr_d;
-      mshr_rdrd_collision_q <= mshr_rdrd_collision_d;
-      miss_req_masked_q     <= miss_req_masked_d;
-      amo_req_q             <= amo_req_d;
-      stores_inflight_q     <= stores_inflight_d;
-    end
-  end
+  `FFARNC(state_q              , state_d              , 1'b0, INIT, clk_i, rst_ni)
+  `FFARNC(cnt_q                , cnt_d                , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(enable_q             , enable_d             , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(flush_ack_q          , flush_ack_d          , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(mshr_vld_q           , mshr_vld_d           , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(mshr_vld_q1          , mshr_vld_q           , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(mshr_q               , mshr_d               , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(mshr_rdrd_collision_q, mshr_rdrd_collision_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(miss_req_masked_q    , miss_req_masked_d    , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(amo_req_q            , amo_req_d            , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(stores_inflight_q    , stores_inflight_d    , 1'b0, '0  , clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/cache_subsystem/wt_dcache_missunit.sv
+++ b/core/cache_subsystem/wt_dcache_missunit.sv
@@ -25,6 +25,7 @@ module wt_dcache_missunit
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,  // Synchronous clear active high
     // cache management, signals from/to core
     input logic enable_i,  // from CSR
     input  logic                                       flush_i,     // flush request, this waits for pending tx (write, read) to finish and will clear the cache
@@ -593,17 +594,17 @@ module wt_dcache_missunit
   // ff's
   ///////////////////////////////////////////////////////
 
-  `FFARNC(state_q              , state_d              , 1'b0, INIT, clk_i, rst_ni)
-  `FFARNC(cnt_q                , cnt_d                , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(enable_q             , enable_d             , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(flush_ack_q          , flush_ack_d          , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(mshr_vld_q           , mshr_vld_d           , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(mshr_vld_q1          , mshr_vld_q           , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(mshr_q               , mshr_d               , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(mshr_rdrd_collision_q, mshr_rdrd_collision_d, 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(miss_req_masked_q    , miss_req_masked_d    , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(amo_req_q            , amo_req_d            , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(stores_inflight_q    , stores_inflight_d    , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, INIT, clk_i, rst_ni)
+  `FFARNC(cnt_q, cnt_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(enable_q, enable_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(flush_ack_q, flush_ack_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(mshr_vld_q, mshr_vld_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(mshr_vld_q1, mshr_vld_q, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(mshr_q, mshr_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(mshr_rdrd_collision_q, mshr_rdrd_collision_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(miss_req_masked_q, miss_req_masked_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(amo_req_q, amo_req_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(stores_inflight_q, stores_inflight_d, clear_i, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -57,9 +57,8 @@ module wt_dcache_wbuffer
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
     input logic clk_i,  // Clock
-    input logic rst_ni, // Asynchronous reset active low
-    input logic clear_i, // Synchronous clear active high
-
+    input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,  // Synchronous clear active high
     input logic cache_en_i,  // writes are treated as NC if disabled
     output logic empty_o,  // asserted if no data is present in write buffer
     output logic not_ni_o,  // asserted if no ni data is present in write buffer

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -58,6 +58,7 @@ module wt_dcache_wbuffer
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni, // Asynchronous reset active low
+    input logic clear_i, // Synchronous clear active high
 
     input logic cache_en_i,  // writes are treated as NC if disabled
     output logic empty_o,  // asserted if no data is present in write buffer
@@ -545,17 +546,17 @@ module wt_dcache_wbuffer
   // ff's
   ///////////////////////////////////////////////////////
 
-  `FFARNC(wbuffer_q    , wbuffer_d   , 1'b0, '{default: '0}, clk_i, rst_ni)
-  `FFARNC(tx_stat_q    , tx_stat_d   , 1'b0, '{default: '0}, clk_i, rst_ni)
-  `FFARNC(ni_pending_q , ni_pending_d, 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(check_ptr_q  , check_ptr_d , 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(check_ptr_q1 , check_ptr_q , 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(check_en_q   , check_en_d  , 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(check_en_q1  , check_en_q  , 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(rd_tag_q     , rd_tag_d    , 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(rd_hit_oh_q  , rd_hit_oh_d , 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(wr_cl_vld_q  , wr_cl_vld_d , 1'b0, '0            , clk_i, rst_ni)
-  `FFARNC(wr_cl_idx_q  , wr_cl_idx_d , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(wbuffer_q, wbuffer_d, clear_i, '{default: '0}, clk_i, rst_ni)
+  `FFARNC(tx_stat_q, tx_stat_d, clear_i, '{default: '0}, clk_i, rst_ni)
+  `FFARNC(ni_pending_q, ni_pending_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(check_ptr_q, check_ptr_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(check_ptr_q1, check_ptr_q, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(check_en_q, check_en_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(check_en_q1, check_en_q, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(rd_tag_q, rd_tag_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(rd_hit_oh_q, rd_hit_oh_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(wr_cl_vld_q, wr_cl_vld_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(wr_cl_idx_q, wr_cl_idx_d, clear_i, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/cache_subsystem/wt_dcache_wbuffer.sv
+++ b/core/cache_subsystem/wt_dcache_wbuffer.sv
@@ -48,6 +48,7 @@
 //    then, only the NC word is written into the write buffer and no further write requests are acknowledged until that
 //    word has been evicted from the write buffer.
 
+`include "common_cells/registers.svh"
 
 module wt_dcache_wbuffer
   import ariane_pkg::*;
@@ -544,34 +545,17 @@ module wt_dcache_wbuffer
   // ff's
   ///////////////////////////////////////////////////////
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
-    if (!rst_ni) begin
-      wbuffer_q    <= '{default: '0};
-      tx_stat_q    <= '{default: '0};
-      ni_pending_q <= '0;
-      check_ptr_q  <= '0;
-      check_ptr_q1 <= '0;
-      check_en_q   <= '0;
-      check_en_q1  <= '0;
-      rd_tag_q     <= '0;
-      rd_hit_oh_q  <= '0;
-      wr_cl_vld_q  <= '0;
-      wr_cl_idx_q  <= '0;
-    end else begin
-      wbuffer_q    <= wbuffer_d;
-      tx_stat_q    <= tx_stat_d;
-      ni_pending_q <= ni_pending_d;
-      check_ptr_q  <= check_ptr_d;
-      check_ptr_q1 <= check_ptr_q;
-      check_en_q   <= check_en_d;
-      check_en_q1  <= check_en_q;
-      rd_tag_q     <= rd_tag_d;
-      rd_hit_oh_q  <= rd_hit_oh_d;
-      wr_cl_vld_q  <= wr_cl_vld_d;
-      wr_cl_idx_q  <= wr_cl_idx_d;
-    end
-  end
-
+  `FFARNC(wbuffer_q    , wbuffer_d   , 1'b0, '{default: '0}, clk_i, rst_ni)
+  `FFARNC(tx_stat_q    , tx_stat_d   , 1'b0, '{default: '0}, clk_i, rst_ni)
+  `FFARNC(ni_pending_q , ni_pending_d, 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(check_ptr_q  , check_ptr_d , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(check_ptr_q1 , check_ptr_q , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(check_en_q   , check_en_d  , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(check_en_q1  , check_en_q  , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(rd_tag_q     , rd_tag_d    , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(rd_hit_oh_q  , rd_hit_oh_d , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(wr_cl_vld_q  , wr_cl_vld_d , 1'b0, '0            , clk_i, rst_ni)
+  `FFARNC(wr_cl_idx_q  , wr_cl_idx_d , 1'b0, '0            , clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -22,6 +22,8 @@ module controller
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear, active high
+    input logic clear_i,
     // VS mode - CSR_REGFILE
     input logic v_i,
     // Reset microarchitecture - SUBSYSTEM
@@ -379,8 +381,8 @@ module controller
   ) i_drain_cnt (
       .clk_i,
       .rst_ni,
-      .clear_i   (cache_busy_i),       // Start counting from 0 when cache is busy
-      .en_i      (drain_cnt != 4'hf),  // Stop counting when saturated
+      .clear_i   (cache_busy_i | clear_i),  // Start counting from 0 when cache is busy
+      .en_i      (drain_cnt != 4'hf),       // Stop counting when saturated
       .load_i    (1'b0),
       .down_i    (1'b0),
       .d_i       ('0),
@@ -394,7 +396,7 @@ module controller
   ) i_pad_cnt (
       .clk_i,
       .rst_ni,
-      .clear_i   (1'b0),
+      .clear_i,
       .en_i      (|pad_cnt),       // Count until 0
       .load_i    (load_pad_cnt),   // Start counting on positive edge of time irq
       .down_i    (1'b1),           // Always count down
@@ -417,15 +419,26 @@ module controller
       priv_lvl_q      <= riscv::PRIV_LVL_M;
       cache_init_q    <= '0;
     end else begin
-      fence_t_state_q <= fence_t_state_d;
-      fence_active_q  <= fence_active_d;
-      rst_uarch_cnt_q <= rst_uarch_cnt_d;
-      // register on the flush signal, this signal might be critical
-      flush_dcache_o  <= flush_dcache;
-      rst_addr_q      <= rst_addr_d;
-      time_irq_q      <= time_irq_i;
-      priv_lvl_q      <= priv_lvl_i;
-      cache_init_q    <= cache_init_d;
+      if (clear_i) begin
+        fence_t_state_q <= IDLE;
+        rst_uarch_cnt_q <= 4'b0;
+        fence_active_q  <= 1'b0;
+        flush_dcache_o  <= 1'b0;
+        rst_addr_q      <= boot_addr_i;
+        time_irq_q      <= 1'b0;
+        priv_lvl_q      <= riscv::PRIV_LVL_M;
+        cache_init_q    <= '0;
+      end else begin
+        fence_t_state_q <= fence_t_state_d;
+        fence_active_q  <= fence_active_d;
+        rst_uarch_cnt_q <= rst_uarch_cnt_d;
+        // register on the flush signal, this signal might be critical
+        flush_dcache_o  <= flush_dcache;
+        rst_addr_q      <= rst_addr_d;
+        time_irq_q      <= time_irq_i;
+        priv_lvl_q      <= priv_lvl_i;
+        cache_init_q    <= cache_init_d;
+      end
     end
   end
 endmodule

--- a/core/controller.sv
+++ b/core/controller.sv
@@ -12,6 +12,7 @@
 // Date: 08.05.2017
 // Description: Flush controller
 
+`include "common_cells/registers.svh"
 
 module controller
   import ariane_pkg::*;
@@ -408,37 +409,13 @@ module controller
   // ----------------------
   // Registers
   // ----------------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      fence_t_state_q <= IDLE;
-      rst_uarch_cnt_q <= 4'b0;
-      fence_active_q  <= 1'b0;
-      flush_dcache_o  <= 1'b0;
-      rst_addr_q      <= boot_addr_i;
-      time_irq_q      <= 1'b0;
-      priv_lvl_q      <= riscv::PRIV_LVL_M;
-      cache_init_q    <= '0;
-    end else begin
-      if (clear_i) begin
-        fence_t_state_q <= IDLE;
-        rst_uarch_cnt_q <= 4'b0;
-        fence_active_q  <= 1'b0;
-        flush_dcache_o  <= 1'b0;
-        rst_addr_q      <= boot_addr_i;
-        time_irq_q      <= 1'b0;
-        priv_lvl_q      <= riscv::PRIV_LVL_M;
-        cache_init_q    <= '0;
-      end else begin
-        fence_t_state_q <= fence_t_state_d;
-        fence_active_q  <= fence_active_d;
-        rst_uarch_cnt_q <= rst_uarch_cnt_d;
-        // register on the flush signal, this signal might be critical
-        flush_dcache_o  <= flush_dcache;
-        rst_addr_q      <= rst_addr_d;
-        time_irq_q      <= time_irq_i;
-        priv_lvl_q      <= priv_lvl_i;
-        cache_init_q    <= cache_init_d;
-      end
-    end
-  end
+  `FFARNC(fence_t_state_q, fence_t_state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(fence_active_q, fence_active_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(rst_uarch_cnt_q, rst_uarch_cnt_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(flush_dcache_o, flush_dcache, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(rst_addr_q, rst_addr_d, clear_i, boot_addr_i, clk_i, rst_ni)
+  `FFARNC(time_irq_q, time_irq_i, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(priv_lvl_q, priv_lvl_i, clear_i, riscv::PRIV_LVL_M, clk_i, rst_ni)
+  `FFARNC(cache_init_q, cache_init_d, clear_i, '0, clk_i, rst_ni)
+
 endmodule

--- a/core/csr_buffer.sv
+++ b/core/csr_buffer.sv
@@ -13,6 +13,7 @@
 // Description: Buffer to hold CSR address, this acts like a functional unit
 //              to the scoreboard.
 
+`include "common_cells/registers.svh"
 
 module csr_buffer
   import ariane_pkg::*;
@@ -23,6 +24,8 @@ module csr_buffer
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Flush CSR - CONTROLLER
     input logic flush_i,
     // FU data needed to execute instruction - ISSUE_STAGE
@@ -71,12 +74,6 @@ module csr_buffer
     if (flush_i) csr_reg_n.valid = 1'b0;
   end
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      csr_reg_q <= '{default: 0};
-    end else begin
-      csr_reg_q <= csr_reg_n;
-    end
-  end
+  `FFARNC(csr_reg_q, csr_reg_n, clear_i, '{default: 0}, clk_i, rst_ni)
 
 endmodule

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -859,6 +859,7 @@ module csr_regfile
     automatic riscv::hgatp_t hgatp;
     automatic logic [63:0] instret;
 
+    mask            = '0;
 
     satp            = satp_q;
     hgatp           = hgatp_q;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -12,6 +12,7 @@
 // Date: 19.03.2017
 // Description: CVA6 Top-level module
 
+`include "common_cells/registers.svh"
 
 module cva6
   import ariane_pkg::*;
@@ -518,13 +519,7 @@ module cva6
   logic                                                  inval_valid;
   logic                                                  inval_ready;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      rst_uarch_n <= 1'b0;
-    end else begin
-      rst_uarch_n <= rst_uarch_controller_n & ~clear_i;
-    end
-  end
+  `FFARN(rst_uarch_n, rst_uarch_controller_n, 1'b0, clk_i, rst_ni)
 
   // ----------------------
   // CLIC Controller <-> ID
@@ -1367,6 +1362,7 @@ module cva6
     ) i_clic_controller (
         .clk_i           (clk_i),
         .rst_ni          (rst_ni),
+        .clear_i         (clear_i),
         // from CSR file
         .priv_lvl_i      (priv_lvl),
         .irq_ctrl_i      (irq_ctrl_csr_id),

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -564,6 +564,7 @@ module cva6
   ) id_stage_i (
       .clk_i,
       .rst_ni (rst_uarch_n),
+      .clear_i,
       .flush_i(flush_ctrl_if),
       .debug_req_i,
 

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -119,6 +119,8 @@ module cva6
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high
+    input logic clear_i,
     // Reset boot address - SUBSYSTEM
     input logic [riscv::VLEN-1:0] boot_addr_i,
     // Hard ID reflected as CSR - SUBSYSTEM
@@ -520,7 +522,7 @@ module cva6
     if (~rst_ni) begin
       rst_uarch_n <= 1'b0;
     end else begin
-      rst_uarch_n <= rst_uarch_controller_n;
+      rst_uarch_n <= rst_uarch_controller_n & ~clear_i;
     end
   end
 
@@ -1446,7 +1448,7 @@ module cva6
   instr_tracer_if tracer_if (clk_i);
   // assign instruction tracer interface
   // control signals
-  assign tracer_if.rstn           = rst_ni;
+  assign tracer_if.rstn           = rst_ni & ~clear_i;
   assign tracer_if.flush_unissued = flush_unissued_instr_ctrl_id;
   assign tracer_if.flush          = flush_ctrl_ex;
   // fetch

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -519,7 +519,7 @@ module cva6
   logic                                                  inval_valid;
   logic                                                  inval_ready;
 
-  `FFARN(rst_uarch_n, rst_uarch_controller_n, 1'b0, clk_i, rst_ni)
+  `FFARNC(rst_uarch_n, rst_uarch_controller_n, clear_i, '0, clk_i, rst_ni)
 
   // ----------------------
   // CLIC Controller <-> ID

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -539,6 +539,7 @@ module cva6
       .CVA6Cfg(CVA6ExtendCfg)
   ) i_frontend (
       .rst_ni             (rst_uarch_n),
+      .clear_i            (clear_i),
       .flush_i            (flush_ctrl_if),                  // not entirely correct
       .flush_bp_i         (1'b0),
       .halt_i             (halt_ctrl),
@@ -675,6 +676,7 @@ module cva6
       .clk_i,
       .rst_ni,
       .rst_uarch_ni          (rst_uarch_n),
+      .clear_i               (clear_i),
       .sb_full_o             (sb_full),
       .flush_unissued_instr_i(flush_unissued_instr_ctrl_id),
       .flush_i               (flush_ctrl_id),
@@ -751,6 +753,7 @@ module cva6
   ) ex_stage_i (
       .clk_i(clk_i),
       .rst_ni(rst_uarch_n),
+      .clear_i(clear_i),
       .debug_mode_i(debug_mode),
       .flush_i(flush_ctrl_ex),
       .rs1_forwarding_i(rs1_forwarding_id_ex),
@@ -1012,6 +1015,7 @@ module cva6
     ) perf_counters_i (
         .clk_i         (clk_i),
         .rst_ni        (rst_ni),
+        .clear_i       (clear_i),
         .debug_mode_i  (debug_mode),
         .addr_i        (addr_csr_perf),
         .we_i          (we_csr_perf),
@@ -1136,6 +1140,7 @@ module cva6
         // to D$
         .clk_i             (clk_i),
         .rst_ni            (rst_uarch_n),
+        .clear_i           (clear_i),
         .busy_o            (busy_cache_ctrl),
         .stall_i           (stall_ctrl_cache),
         .init_ni           (init_ctrl_cache_n),
@@ -1242,6 +1247,7 @@ module cva6
         // to D$
         .clk_i             (clk_i),
         .rst_ni            (rst_uarch_n),
+        .clear_i           (clear_i),
         .priv_lvl_i        (priv_lvl),
         .busy_o            (busy_cache_ctrl),
         .stall_i           (stall_ctrl_cache),
@@ -1500,7 +1506,7 @@ module cva6
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
+    if (~rst_ni | clear_i) begin
       cycles <= 0;
     end else begin
       byte mode = "";

--- a/core/cva6_clic_controller.sv
+++ b/core/cva6_clic_controller.sv
@@ -91,5 +91,5 @@ module cva6_clic_controller #(
   // Acknowledge kill if no irq is inflight and irq is not accepted this cycle
   assign clic_kill_ack_o = clic_kill_req_i & ~irq_inflight_q & ~clic_irq_req_o;
 
-  `FFARNC(mult_result_q, irq_inflight_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(irq_inflight_q, irq_inflight_d, clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/cva6_clic_controller.sv
+++ b/core/cva6_clic_controller.sv
@@ -4,11 +4,14 @@
 //
 // Author: Nils Wistoff <nwistoff@iis.ee.ethz.ch>
 
+`include "common_cells/registers.svh"
+
 module cva6_clic_controller #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     // from CSR file
     input riscv::priv_lvl_t priv_lvl_i,  // current privilege level
     input ariane_pkg::irq_ctrl_t irq_ctrl_i,
@@ -88,11 +91,5 @@ module cva6_clic_controller #(
   // Acknowledge kill if no irq is inflight and irq is not accepted this cycle
   assign clic_kill_ack_o = clic_kill_req_i & ~irq_inflight_q & ~clic_irq_req_o;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      irq_inflight_q <= 1'b0;
-    end else begin
-      irq_inflight_q <= irq_inflight_d;
-    end
-  end
+  `FFARNC(mult_result_q, irq_inflight_d, clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/cva6_rvfi.sv
+++ b/core/cva6_rvfi.sv
@@ -8,6 +8,7 @@
 // Original Author: Yannick Casamatta - Thales
 // Date: 09/01/2024
 
+`include "common_cells/registers.svh"
 
 module cva6_rvfi
   import ariane_pkg::*;
@@ -19,6 +20,7 @@ module cva6_rvfi
 
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
 
     input rvfi_probes_t rvfi_probes_i,
     output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o
@@ -204,13 +206,7 @@ module cva6_rvfi
     if (flush) issue_n.valid = 1'b0;
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      issue_q <= '0;
-    end else begin
-      issue_q <= issue_n;
-    end
-  end
+  `FFARNC(issue_q, issue_n, clear_i, '0, clk_i, rst_ni)
 
   //ISSUE STAGE
 
@@ -251,13 +247,7 @@ module cva6_rvfi
     end
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : regs
-    if (!rst_ni) begin
-      mem_q <= '{default: sb_mem_t'(0)};
-    end else begin
-      mem_q <= mem_n;
-    end
-  end
+  `FFARNC(mem_q, mem_n, clear_i, '{default: sb_mem_t'(0)}, clk_i, rst_ni)
 
   //----------------------------------------------------------------------------------------------------------
   // PACK

--- a/core/cvxif_example/cvxif_example_coprocessor.sv
+++ b/core/cvxif_example/cvxif_example_coprocessor.sv
@@ -103,7 +103,7 @@ module cvxif_example_coprocessor
   assign req_i.req = x_issue_req_i;
   assign req_i.resp = x_issue_resp_o;
 
-  `FFARNC(x_issue_ready_o, x_issue_ready_q, 1'b0, 1'b1, clk_i, rst_ni)
+  `FFARNC(x_issue_ready_o, x_issue_ready_q, clear_i, 1'b1, clk_i, rst_ni)
 
   fifo_v3 #(
       .FALL_THROUGH(1),         //data_o ready and pop in the same cycle

--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -117,8 +117,8 @@ module cvxif_fu
     end
   end
 
-  `FFARNC(illegal_q      , illegal_n      , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(illegal_id_q   , illegal_id_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(illegal_q, illegal_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(illegal_id_q, illegal_id_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(illegal_instr_q, illegal_instr_n, clear_i, '0, clk_i, rst_ni)
 
 endmodule

--- a/core/cvxif_fu.sv
+++ b/core/cvxif_fu.sv
@@ -9,6 +9,7 @@
 
 // Functional Unit for the logic of the CoreV-X-Interface
 
+`include "common_cells/registers.svh"
 
 module cvxif_fu
   import ariane_pkg::*;
@@ -19,6 +20,8 @@ module cvxif_fu
     input  logic                                       clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input  logic                                       rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input  logic                                       clear_i,
     // FU data needed to execute instruction - ISSUE_STAGE
     input  fu_data_t                                   fu_data_i,
     // Current privilege mode - CSR_REGFILE
@@ -114,16 +117,8 @@ module cvxif_fu
     end
   end
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (~rst_ni) begin
-      illegal_q       <= 1'b0;
-      illegal_id_q    <= '0;
-      illegal_instr_q <= '0;
-    end else begin
-      illegal_q       <= illegal_n;
-      illegal_id_q    <= illegal_id_n;
-      illegal_instr_q <= illegal_instr_n;
-    end
-  end
+  `FFARNC(illegal_q      , illegal_n      , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(illegal_id_q   , illegal_id_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(illegal_instr_q, illegal_instr_n, clear_i, '0, clk_i, rst_ni)
 
 endmodule

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -506,22 +506,22 @@ module ex_stage
   end
 
   logic [5:0] load_enable;
-  assign load_enable[0] = fu_data_i.operation == SFENCE_VMA && !v_i && csr_valid_i ? 1'b1 : 1'b0;
-  assign load_enable[1] = ((fu_data_i.operation == SFENCE_VMA && v_i) || fu_data_i.operation == HFENCE_VVMA) && csr_valid_i ? 1'b1 : 1'b0;
-  assign load_enable[2] = (fu_data_i.operation == HFENCE_GVMA) && csr_valid_i ? 1'b1 : 1'b0;
-  assign load_enable[3] = fu_data_i.operation == SFENCE_VMA && csr_valid_i ? 1'b1 : 1'b0;
-  assign load_enable[4] = (~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA ) && csr_valid_i)) ? 1'b1 : 1'b0;
-  assign load_enable[5] = (~current_instruction_is_sfence_vma) && (~((fu_data_i.operation == SFENCE_VMA) && csr_valid_i)) ? 1'b1 : 1'b0;
+  assign load_enable[0] = ((fu_data_i.operation == SFENCE_VMA && !v_i) && csr_valid_i) ? 1'b1 : 1'b0;
+  assign load_enable[1] = (((fu_data_i.operation == SFENCE_VMA && v_i) || fu_data_i.operation == HFENCE_VVMA) && csr_valid_i) ? 1'b1 : 1'b0;
+  assign load_enable[2] = ((fu_data_i.operation == HFENCE_GVMA) && csr_valid_i) ? 1'b1 : 1'b0;
+  assign load_enable[3] = (fu_data_i.operation == SFENCE_VMA && csr_valid_i) ? 1'b1 : 1'b0;
+  assign load_enable[4] = ((~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA ) && csr_valid_i))) ? 1'b1 : 1'b0;
+  assign load_enable[5] = ((~current_instruction_is_sfence_vma) && (~((fu_data_i.operation == SFENCE_VMA) && csr_valid_i))) ? 1'b1 : 1'b0;
 
   if (CVA6Cfg.RVS) begin
     if (CVA6Cfg.RVH) begin
-      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[0], clear_i, '0, clk_i, rst_ni)
-      `FFLARNC(current_instruction_is_hfence_vvma, '1, load_enable[1], clear_i, '0, clk_i, rst_ni)
-      `FFLARNC(current_instruction_is_hfence_gvma, '1, load_enable[2], clear_i, '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[0], (flush_i | clear_i), '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_hfence_vvma, '1, load_enable[1], (flush_i | clear_i), '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_hfence_gvma, '1, load_enable[2], (flush_i | clear_i), '0, clk_i, rst_ni)
     end else begin
       assign current_instruction_is_hfence_vvma = 1'b0;
       assign current_instruction_is_hfence_gvma = 1'b0;
-      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[3], clear_i, '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[3], (flush_i | clear_i), '0, clk_i, rst_ni)
     end
     if (CVA6Cfg.RVH) begin
       assign asid_rs2_forwarding = rs2_forwarding_i[ASID_WIDTH-1:0];

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -241,6 +241,8 @@ module ex_stage
   //                        instructions.
 
 
+  logic clear;
+  logic [5:0] load_enable;
   logic current_instruction_is_sfence_vma;
   logic current_instruction_is_hfence_vvma;
   logic current_instruction_is_hfence_gvma;
@@ -505,7 +507,7 @@ module ex_stage
     assign x_valid_o     = '0;
   end
 
-  logic [5:0] load_enable;
+  assign clear = flush_i | clear_i;
   assign load_enable[0] = ((fu_data_i.operation == SFENCE_VMA && !v_i) && csr_valid_i) ? 1'b1 : 1'b0;
   assign load_enable[1] = (((fu_data_i.operation == SFENCE_VMA && v_i) || fu_data_i.operation == HFENCE_VVMA) && csr_valid_i) ? 1'b1 : 1'b0;
   assign load_enable[2] = ((fu_data_i.operation == HFENCE_GVMA) && csr_valid_i) ? 1'b1 : 1'b0;
@@ -515,13 +517,13 @@ module ex_stage
 
   if (CVA6Cfg.RVS) begin
     if (CVA6Cfg.RVH) begin
-      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[0], (flush_i | clear_i), '0, clk_i, rst_ni)
-      `FFLARNC(current_instruction_is_hfence_vvma, '1, load_enable[1], (flush_i | clear_i), '0, clk_i, rst_ni)
-      `FFLARNC(current_instruction_is_hfence_gvma, '1, load_enable[2], (flush_i | clear_i), '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[0], clear, '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_hfence_vvma, '1, load_enable[1], clear, '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_hfence_gvma, '1, load_enable[2], clear, '0, clk_i, rst_ni)
     end else begin
       assign current_instruction_is_hfence_vvma = 1'b0;
       assign current_instruction_is_hfence_gvma = 1'b0;
-      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[3], (flush_i | clear_i), '0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_sfence_vma, '1, load_enable[3], clear, '0, clk_i, rst_ni)
     end
     if (CVA6Cfg.RVH) begin
       assign asid_rs2_forwarding = rs2_forwarding_i[ASID_WIDTH-1:0];

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -13,6 +13,7 @@
 // Date: 19.04.2017
 // Description: Instantiation of all functional units residing in the execute stage
 
+`include "common_cells/registers.svh"
 
 module ex_stage
   import ariane_pkg::*;
@@ -25,6 +26,8 @@ module ex_stage
     input  logic                                                        clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input  logic                                                        rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input  logic                                                        clear_i,
     // Fetch flush request - CONTROLLER
     input  logic                                                        flush_i,
     // Debug mode is enabled - CSR_REGFILE
@@ -301,6 +304,7 @@ module ex_stage
   ) csr_buffer_i (
       .clk_i,
       .rst_ni,
+      .clear_i,
       .flush_i,
       .fu_data_i,
       .csr_valid_i,
@@ -344,6 +348,7 @@ module ex_stage
   ) i_mult (
       .clk_i,
       .rst_ni,
+      .clear_i(clear_i),
       .flush_i,
       .mult_valid_i,
       .fu_data_i      (mult_data),
@@ -366,6 +371,7 @@ module ex_stage
       ) fpu_i (
           .clk_i,
           .rst_ni,
+          .clear_i,
           .flush_i,
           .fpu_valid_i,
           .fpu_ready_o,
@@ -402,6 +408,7 @@ module ex_stage
   ) lsu_i (
       .clk_i,
       .rst_ni,
+      .clear_i,
       .flush_i,
       .stall_st_pending_i,
       .no_st_pending_o,
@@ -471,6 +478,7 @@ module ex_stage
     ) cvxif_fu_i (
         .clk_i,
         .rst_ni,
+        .clear_i,
         .fu_data_i,
         .priv_lvl_i(ld_st_priv_lvl_i),
         .x_valid_i,
@@ -492,72 +500,36 @@ module ex_stage
     assign x_valid_o     = '0;
   end
 
+  logic [5:0] load_enable;
+  assign load_enable[0] = fu_data_i.operation == SFENCE_VMA && !v_i && csr_valid_i ? 1'b1 : 1'b0;
+  assign load_enable[1] = ((fu_data_i.operation == SFENCE_VMA && v_i) || fu_data_i.operation == HFENCE_VVMA) && csr_valid_i ? 1'b1 : 1'b0;
+  assign load_enable[2] = (fu_data_i.operation == HFENCE_GVMA) && csr_valid_i ? 1'b1 : 1'b0;
+  assign load_enable[3] = fu_data_i.operation == SFENCE_VMA && csr_valid_i ? 1'b1 : 1'b0;
+  assign load_enable[4] = (~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA ) && csr_valid_i)) ? 1'b1 : 1'b0;
+  assign load_enable[5] = (~current_instruction_is_sfence_vma) && (~((fu_data_i.operation == SFENCE_VMA) && csr_valid_i)) ? 1'b1 : 1'b0;
+
   if (CVA6Cfg.RVS) begin
     if (CVA6Cfg.RVH) begin
-      always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-          current_instruction_is_sfence_vma  <= 1'b0;
-          current_instruction_is_hfence_vvma <= 1'b0;
-          current_instruction_is_hfence_gvma <= 1'b0;
-        end else begin
-          if (flush_i) begin
-            current_instruction_is_sfence_vma  <= 1'b0;
-            current_instruction_is_hfence_vvma <= 1'b0;
-            current_instruction_is_hfence_gvma <= 1'b0;
-          end else if ((fu_data_i.operation == SFENCE_VMA && !v_i) && csr_valid_i) begin
-            current_instruction_is_sfence_vma <= 1'b1;
-          end else if (((fu_data_i.operation == SFENCE_VMA && v_i) || fu_data_i.operation == HFENCE_VVMA) && csr_valid_i) begin
-            current_instruction_is_hfence_vvma <= 1'b1;
-          end else if ((fu_data_i.operation == HFENCE_GVMA) && csr_valid_i) begin
-            current_instruction_is_hfence_gvma <= 1'b1;
-          end
-        end
-      end
+      `FFLARNC(current_instruction_is_sfence_vma , 1'b1, load_enable[0], clear_i, 1'b0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_hfence_vvma, 1'b1, load_enable[1], clear_i, 1'b0, clk_i, rst_ni)
+      `FFLARNC(current_instruction_is_hfence_gvma, 1'b1, load_enable[2], clear_i, 1'b0, clk_i, rst_ni)
     end else begin
       assign current_instruction_is_hfence_vvma = 1'b0;
       assign current_instruction_is_hfence_gvma = 1'b0;
-      always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-          current_instruction_is_sfence_vma <= 1'b0;
-        end else begin
-          if (flush_i) begin
-            current_instruction_is_sfence_vma <= 1'b0;
-          end else if (fu_data_i.operation == SFENCE_VMA && csr_valid_i) begin
-            current_instruction_is_sfence_vma <= 1'b1;
-          end
-        end
-      end
+      `FFLARNC(current_instruction_is_sfence_vma, 1'b1, load_enable[3], clear_i, 1'b0, clk_i, rst_ni)
     end
     if (CVA6Cfg.RVH) begin
       // This process stores the rs1 and rs2 parameters of a SFENCE_VMA instruction.
-      always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-          vmid_to_be_flushed   <= '0;
-          asid_to_be_flushed   <= '0;
-          vaddr_to_be_flushed  <= '0;
-          gpaddr_to_be_flushed <= '0;
-          // if the current instruction in EX_STAGE is a sfence.vma, in the next cycle no writes will happen
-        end else if ((~(current_instruction_is_sfence_vma || current_instruction_is_hfence_vvma || current_instruction_is_hfence_gvma)) && (~((fu_data_i.operation == SFENCE_VMA || fu_data_i.operation == HFENCE_VVMA || fu_data_i.operation == HFENCE_GVMA ) && csr_valid_i))) begin
-          vaddr_to_be_flushed  <= rs1_forwarding_i;
-          gpaddr_to_be_flushed <= rs1_forwarding_i >> 2;
-          asid_to_be_flushed   <= rs2_forwarding_i[ASID_WIDTH-1:0];
-          vmid_to_be_flushed   <= rs2_forwarding_i[VMID_WIDTH-1:0];
-        end
-      end
+      `FFLARNC(vaddr_to_be_flushed , rs1_forwarding_i                , load_enable[4], clear_i, '0, clk_i, rst_ni)
+      `FFLARNC(gpaddr_to_be_flushed, rs1_forwarding_i >> 2           , load_enable[4], clear_i, '0, clk_i, rst_ni)
+      `FFLARNC(asid_to_be_flushed  , rs2_forwarding_i[ASID_WIDTH-1:0], load_enable[4], clear_i, '0, clk_i, rst_ni)
+      `FFLARNC(vmid_to_be_flushed  , rs2_forwarding_i[VMID_WIDTH-1:0], load_enable[4], clear_i, '0, clk_i, rst_ni)
     end else begin
       assign vmid_to_be_flushed   = '0;
       assign gpaddr_to_be_flushed = '0;
       // This process stores the rs1 and rs2 parameters of a SFENCE_VMA instruction.
-      always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-          asid_to_be_flushed  <= '0;
-          vaddr_to_be_flushed <= '0;
-          // if the current instruction in EX_STAGE is a sfence.vma, in the next cycle no writes will happen
-        end else if ((~current_instruction_is_sfence_vma) && (~((fu_data_i.operation == SFENCE_VMA) && csr_valid_i))) begin
-          vaddr_to_be_flushed <= rs1_forwarding_i;
-          asid_to_be_flushed  <= rs2_forwarding_i[ASID_WIDTH-1:0];
-        end
-      end
+      `FFLARNC(vaddr_to_be_flushed, rs1_forwarding_i                , load_enable[5], clear_i, '0, clk_i, rst_ni)
+      `FFLARNC(asid_to_be_flushed , rs2_forwarding_i[ASID_WIDTH-1:0], load_enable[5], clear_i, '0, clk_i, rst_ni)
     end
   end else begin
     assign current_instruction_is_sfence_vma  = 1'b0;

--- a/core/fpu_wrap.sv
+++ b/core/fpu_wrap.sv
@@ -12,6 +12,7 @@
 // Date: 12.04.2018
 // Description: Wrapper for the floating-point unit
 
+`include "common_cells/registers.svh"
 
 module fpu_wrap
   import ariane_pkg::*;
@@ -475,53 +476,19 @@ module fpu_wrap
     end
 
     // Buffer register and FSM state holding
-    always_ff @(posedge clk_i or negedge rst_ni) begin : fp_hold_reg
-      if (~rst_ni) begin
-        state_q      <= READY;
-        operand_a_q  <= '0;
-        operand_b_q  <= '0;
-        operand_c_q  <= '0;
-        fpu_op_q     <= '0;
-        fpu_op_mod_q <= '0;
-        fpu_srcfmt_q <= '0;
-        fpu_dstfmt_q <= '0;
-        fpu_ifmt_q   <= '0;
-        fpu_rm_q     <= '0;
-        fpu_vec_op_q <= '0;
-        fpu_tag_q    <= '0;
-      end else begin
-        if (clear_i) begin
-          state_q      <= READY;
-          operand_a_q  <= '0;
-          operand_b_q  <= '0;
-          operand_c_q  <= '0;
-          fpu_op_q     <= '0;
-          fpu_op_mod_q <= '0;
-          fpu_srcfmt_q <= '0;
-          fpu_dstfmt_q <= '0;
-          fpu_ifmt_q   <= '0;
-          fpu_rm_q     <= '0;
-          fpu_vec_op_q <= '0;
-          fpu_tag_q    <= '0;
-        end else begin
-          state_q <= state_d;
-          // Hold register is [TRIGGERED] by FSM
-          if (hold_inputs) begin
-            operand_a_q  <= operand_a_d;
-            operand_b_q  <= operand_b_d;
-            operand_c_q  <= operand_c_d;
-            fpu_op_q     <= fpu_op_d;
-            fpu_op_mod_q <= fpu_op_mod_d;
-            fpu_srcfmt_q <= fpu_srcfmt_d;
-            fpu_dstfmt_q <= fpu_dstfmt_d;
-            fpu_ifmt_q   <= fpu_ifmt_d;
-            fpu_rm_q     <= fpu_rm_d;
-            fpu_vec_op_q <= fpu_vec_op_d;
-            fpu_tag_q    <= fpu_tag_d;
-          end
-        end
-      end
-    end
+    `FFARNC(state_q, state_d, clear_i, READY, clk_i, rst_ni)
+    // Hold register is [TRIGGERED] by FSM
+    `FFLARNC(operand_a_q, operand_a_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(operand_b_q, operand_b_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(operand_c_q, operand_c_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_op_q, fpu_op_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_op_mod_q, fpu_op_mod_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_srcfmt_q, fpu_srcfmt_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_dstfmt_q, fpu_dstfmt_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_ifmt_q, fpu_ifmt_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_rm_q, fpu_rm_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_vec_op_q, fpu_vec_op_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
+    `FFLARNC(fpu_tag_q, fpu_tag_d, hold_inputs, clear_i, '0, clk_i, rst_ni)
 
     // Select FPU input data: from register if valid data in register, else directly from input
     assign operand_a  = use_hold ? operand_a_q : operand_a_d;

--- a/core/fpu_wrap.sv
+++ b/core/fpu_wrap.sv
@@ -20,6 +20,7 @@ module fpu_wrap
 ) (
     input  logic     clk_i,
     input  logic     rst_ni,
+    input  logic     clear_i,
     input  logic     flush_i,
     input  logic     fpu_valid_i,
     output logic     fpu_ready_o,
@@ -489,20 +490,35 @@ module fpu_wrap
         fpu_vec_op_q <= '0;
         fpu_tag_q    <= '0;
       end else begin
-        state_q <= state_d;
-        // Hold register is [TRIGGERED] by FSM
-        if (hold_inputs) begin
-          operand_a_q  <= operand_a_d;
-          operand_b_q  <= operand_b_d;
-          operand_c_q  <= operand_c_d;
-          fpu_op_q     <= fpu_op_d;
-          fpu_op_mod_q <= fpu_op_mod_d;
-          fpu_srcfmt_q <= fpu_srcfmt_d;
-          fpu_dstfmt_q <= fpu_dstfmt_d;
-          fpu_ifmt_q   <= fpu_ifmt_d;
-          fpu_rm_q     <= fpu_rm_d;
-          fpu_vec_op_q <= fpu_vec_op_d;
-          fpu_tag_q    <= fpu_tag_d;
+        if (clear_i) begin
+          state_q      <= READY;
+          operand_a_q  <= '0;
+          operand_b_q  <= '0;
+          operand_c_q  <= '0;
+          fpu_op_q     <= '0;
+          fpu_op_mod_q <= '0;
+          fpu_srcfmt_q <= '0;
+          fpu_dstfmt_q <= '0;
+          fpu_ifmt_q   <= '0;
+          fpu_rm_q     <= '0;
+          fpu_vec_op_q <= '0;
+          fpu_tag_q    <= '0;
+        end else begin
+          state_q <= state_d;
+          // Hold register is [TRIGGERED] by FSM
+          if (hold_inputs) begin
+            operand_a_q  <= operand_a_d;
+            operand_b_q  <= operand_b_d;
+            operand_c_q  <= operand_c_d;
+            fpu_op_q     <= fpu_op_d;
+            fpu_op_mod_q <= fpu_op_mod_d;
+            fpu_srcfmt_q <= fpu_srcfmt_d;
+            fpu_dstfmt_q <= fpu_dstfmt_d;
+            fpu_ifmt_q   <= fpu_ifmt_d;
+            fpu_rm_q     <= fpu_rm_d;
+            fpu_vec_op_q <= fpu_vec_op_d;
+            fpu_tag_q    <= fpu_tag_d;
+          end
         end
       end
     end

--- a/core/frontend/bht.sv
+++ b/core/frontend/bht.sv
@@ -110,16 +110,20 @@ module bht #(
           end
         end
       end else begin
-        // evict all entries
-        if (flush_i | clear_i) begin
-          for (int i = 0; i < NR_ROWS; i++) begin
-            for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
-              bht_q[i][j].valid <= 1'b0;
-              bht_q[i][j].saturation_counter <= 2'b10;
-            end
-          end
+        if (clear_i) begin
+          bht_q <= '0;
         end else begin
-          bht_q <= bht_d;
+          // evict all entries
+          if (flush_i) begin
+            for (int i = 0; i < NR_ROWS; i++) begin
+              for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
+                bht_q[i][j].valid <= 1'b0;
+                bht_q[i][j].saturation_counter <= 2'b10;
+              end
+            end
+          end else begin
+            bht_q <= bht_d;
+          end
         end
       end
     end

--- a/core/frontend/bht.sv
+++ b/core/frontend/bht.sv
@@ -26,6 +26,8 @@ module bht #(
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Fetch flush request - CONTROLLER
     input logic flush_i,
     // Debug mode state - CSR
@@ -109,7 +111,7 @@ module bht #(
         end
       end else begin
         // evict all entries
-        if (flush_i) begin
+        if (flush_i | clear_i) begin
           for (int i = 0; i < NR_ROWS; i++) begin
             for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
               bht_q[i][j].valid <= 1'b0;

--- a/core/frontend/bht.sv
+++ b/core/frontend/bht.sv
@@ -111,7 +111,11 @@ module bht #(
         end
       end else begin
         if (clear_i) begin
-          bht_q <= '0;
+          for (int unsigned i = 0; i < NR_ROWS; i++) begin
+            for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
+              bht_q[i][j] <= '0;
+            end
+          end
         end else begin
           // evict all entries
           if (flush_i) begin

--- a/core/frontend/btb.sv
+++ b/core/frontend/btb.sv
@@ -33,6 +33,8 @@ module btb #(
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Fetch flush request - CONTROLLER
     input logic flush_i,
     // Debug mode state - CSR
@@ -176,7 +178,7 @@ module btb #(
         for (int i = 0; i < NR_ROWS; i++) btb_q[i] <= '{default: 0};
       end else begin
         // evict all entries
-        if (flush_i) begin
+        if (flush_i | clear_i) begin
           for (int i = 0; i < NR_ROWS; i++) begin
             for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
               btb_q[i][j].valid <= 1'b0;

--- a/core/frontend/btb.sv
+++ b/core/frontend/btb.sv
@@ -178,7 +178,7 @@ module btb #(
         for (int i = 0; i < NR_ROWS; i++) btb_q[i] <= '{default: 0};
       end else begin
         if (clear_i) begin
-          btb_q <= '{default: 0};
+          for (int i = 0; i < NR_ROWS; i++) btb_q[i] <= '{default: 0};
         end else begin
           // evict all entries
           if (flush_i | clear_i) begin

--- a/core/frontend/btb.sv
+++ b/core/frontend/btb.sv
@@ -177,15 +177,19 @@ module btb #(
         // Bias the branches to be taken upon first arrival
         for (int i = 0; i < NR_ROWS; i++) btb_q[i] <= '{default: 0};
       end else begin
-        // evict all entries
-        if (flush_i | clear_i) begin
-          for (int i = 0; i < NR_ROWS; i++) begin
-            for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
-              btb_q[i][j].valid <= 1'b0;
-            end
-          end
+        if (clear_i) begin
+          btb_q <= '{default: 0};
         end else begin
-          btb_q <= btb_d;
+          // evict all entries
+          if (flush_i | clear_i) begin
+            for (int i = 0; i < NR_ROWS; i++) begin
+              for (int j = 0; j < ariane_pkg::INSTR_PER_FETCH; j++) begin
+                btb_q[i][j].valid <= 1'b0;
+              end
+            end
+          end else begin
+            btb_q <= btb_d;
+          end
         end
       end
     end

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -461,7 +461,7 @@ module frontend
     ) i_ras (
         .clk_i,
         .rst_ni,
-        .clear_i (clear_i),
+        .clear_i,
         .flush_i(flush_bp_i),
         .push_i (ras_push),
         .pop_i  (ras_pop),

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -43,6 +43,8 @@
 // the replay mechanism gets more complicated as it can be that a 32 bit instruction
 // can not be pushed at once.
 
+`include "common_cells/registers.svh"
+
 module instr_queue
   import ariane_pkg::*;
 #(
@@ -52,6 +54,8 @@ module instr_queue
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Fetch flush request - CONTROLLER
     input logic flush_i,
     // Instruction - instr_realign
@@ -457,17 +461,24 @@ ariane_pkg::FETCH_FIFO_DEPTH
         pc_q            <= '0;
         reset_address_q <= 1'b1;
       end else begin
-        pc_q            <= pc_d;
-        reset_address_q <= reset_address_d;
-        if (flush_i) begin
-          // one-hot encoded
+        if (clear_i) begin
           idx_ds_q        <= 'b1;
-          // binary encoded
           idx_is_q        <= '0;
+          pc_q            <= '0;
           reset_address_q <= 1'b1;
         end else begin
-          idx_ds_q <= idx_ds_d;
-          idx_is_q <= idx_is_d;
+          pc_q            <= pc_d;
+          reset_address_q <= reset_address_d;
+          if (flush_i) begin
+            // one-hot encoded
+            idx_ds_q        <= 'b1;
+            // binary encoded
+            idx_is_q        <= '0;
+            reset_address_q <= 1'b1;
+          end else begin
+            idx_ds_q <= idx_ds_d;
+            idx_is_q <= idx_is_d;
+          end
         end
       end
     end

--- a/core/frontend/instr_queue.sv
+++ b/core/frontend/instr_queue.sv
@@ -490,10 +490,15 @@ ariane_pkg::FETCH_FIFO_DEPTH
         pc_q            <= '0;
         reset_address_q <= 1'b1;
       end else begin
-        pc_q            <= pc_d;
-        reset_address_q <= reset_address_d;
-        if (flush_i) begin
+        if (clear_i) begin
+          pc_q            <= '0;
           reset_address_q <= 1'b1;
+        end else begin
+          pc_q            <= pc_d;
+          reset_address_q <= reset_address_d;
+          if (flush_i) begin
+            reset_address_q <= 1'b1;
+          end
         end
       end
     end

--- a/core/frontend/ras.sv
+++ b/core/frontend/ras.sv
@@ -14,6 +14,9 @@
 // Date: 09.06.2018
 
 // return address stack
+
+`include "common_cells/registers.svh"
+
 module ras #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter int unsigned DEPTH = 2
@@ -22,6 +25,8 @@ module ras #(
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Fetch flush request - CONTROLLER
     input logic flush_i,
     // Push address in RAS - FRONTEND
@@ -68,11 +73,6 @@ module ras #(
     end
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      stack_q <= '0;
-    end else begin
-      stack_q <= stack_d;
-    end
-  end
+  `FFARNC(stack_q, stack_d, clear_i, '0, clk_i, rst_ni)
+
 endmodule

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -13,6 +13,8 @@
 // Description: Instruction decode, contains the logic for decode,
 //              issue and read operands.
 
+`include "common_cells/registers.svh"
+
 module id_stage #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty
 ) (
@@ -178,11 +180,5 @@ module id_stage #(
   // -------------------------
   // Registers (ID <-> Issue)
   // -------------------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      issue_q <= '0;
-    end else begin
-      issue_q <= issue_n;
-    end
-  end
+  `FFARNC(issue_q, issue_n, 1'b0, '0, clk_i, rst_ni)
 endmodule

--- a/core/id_stage.sv
+++ b/core/id_stage.sv
@@ -22,6 +22,8 @@ module id_stage #(
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Fetch flush request - CONTROLLER
     input logic flush_i,
     // Debug (async) request - SUBSYSTEM
@@ -180,5 +182,5 @@ module id_stage #(
   // -------------------------
   // Registers (ID <-> Issue)
   // -------------------------
-  `FFARNC(issue_q, issue_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(issue_q, issue_n, clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/instr_realign.sv
+++ b/core/instr_realign.sv
@@ -29,6 +29,8 @@ module instr_realign
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Syynchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Fetch flush request - CONTROLLER
     input logic flush_i,
     // 32-bit block is valid - CACHE
@@ -356,15 +358,21 @@ module instr_realign
       unaligned_address_q <= '0;
       unaligned_instr_q   <= '0;
     end else begin
-      if (valid_i) begin
-        unaligned_address_q <= unaligned_address_d;
-        unaligned_instr_q   <= unaligned_instr_d;
-      end
+      if (clear_i) begin
+        unaligned_q         <= 1'b0;
+        unaligned_address_q <= '0;
+        unaligned_instr_q   <= '0;
+      end else begin
+        if (valid_i) begin
+          unaligned_address_q <= unaligned_address_d;
+          unaligned_instr_q   <= unaligned_instr_d;
+        end
 
-      if (flush_i) begin
-        unaligned_q <= 1'b0;
-      end else if (valid_i) begin
-        unaligned_q <= unaligned_d;
+        if (flush_i) begin
+          unaligned_q <= 1'b0;
+        end else if (valid_i) begin
+          unaligned_q <= unaligned_d;
+        end
       end
     end
   end

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -508,6 +508,7 @@ module issue_read_operands
         .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
         .ZERO_REG_ZERO(1)
     ) i_ariane_regfile (
+        .clear_i  (~rst_uarch_ni),
         .test_en_i(1'b0),
         .raddr_i  (raddr_pack),
         .rdata_o  (rdata),
@@ -557,6 +558,7 @@ module issue_read_operands
             .NR_READ_PORTS(3),
             .ZERO_REG_ZERO(0)
         ) i_ariane_fp_regfile (
+            .clear_i  (~rst_uarch_ni),
             .test_en_i(1'b0),
             .raddr_i  (fp_raddr_pack),
             .rdata_o  (fprdata),

--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -526,7 +526,7 @@ module issue_read_operands
         .NR_READ_PORTS(CVA6Cfg.NrRgprPorts),
         .ZERO_REG_ZERO(1)
     ) i_ariane_regfile (
-        .clear_i  (~rst_uarch_ni),
+        .clear_i  (clear_i),
         .test_en_i(1'b0),
         .raddr_i  (raddr_pack),
         .rdata_o  (rdata),
@@ -576,7 +576,7 @@ module issue_read_operands
             .NR_READ_PORTS(3),
             .ZERO_REG_ZERO(0)
         ) i_ariane_fp_regfile (
-            .clear_i  (~rst_uarch_ni),
+            .clear_i  (clear_i),
             .test_en_i(1'b0),
             .raddr_i  (fp_raddr_pack),
             .rdata_o  (fprdata),

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -166,7 +166,6 @@ module issue_stage
       .CVA6Cfg  (CVA6Cfg),
       .rs3_len_t(rs3_len_t)
   ) i_scoreboard (
-      .clear_i(clear_i),
       .rst_ni(rst_uarch_ni),
 
       .sb_full_o          (sb_full_o),

--- a/core/issue_stage.sv
+++ b/core/issue_stage.sv
@@ -23,6 +23,8 @@ module issue_stage
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Microreset active low - CONTROLLER
     input logic rst_uarch_ni,
     // Is scoreboard full - PERF_COUNTERS
@@ -164,6 +166,7 @@ module issue_stage
       .CVA6Cfg  (CVA6Cfg),
       .rs3_len_t(rs3_len_t)
   ) i_scoreboard (
+      .clear_i(clear_i),
       .rst_ni(rst_uarch_ni),
 
       .sb_full_o          (sb_full_o),

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -331,9 +331,9 @@ module load_store_unit
     assign dtlb_ppn                            = mmu_vaddr_plen[riscv::PLEN-1:12];
     assign dtlb_hit                            = 1'b1;
 
-    `FFARNC(mmu_paddr        , mmu_vaddr_plen      , clear_i, '0, clk_i, rst_ni)
-    `FFARNC(translation_valid, translation_req     , clear_i, '0, clk_i, rst_ni)
-    `FFARNC(mmu_exception    , misaligned_exception, clear_i, '0, clk_i, rst_ni)
+    `FFARNC(mmu_paddr, mmu_vaddr_plen, clear_i, '0, clk_i, rst_ni)
+    `FFARNC(translation_valid, translation_req, clear_i, '0, clk_i, rst_ni)
+    `FFARNC(mmu_exception, misaligned_exception, clear_i, '0, clk_i, rst_ni)
   end
 
 

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -12,6 +12,7 @@
 // Date: 19.04.2017
 // Description: Load Store Unit, handles address calculation and memory interface signals
 
+`include "common_cells/registers.svh"
 
 module load_store_unit
   import ariane_pkg::*;
@@ -24,6 +25,8 @@ module load_store_unit
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // TO_BE_COMPLETED - TO_BE_COMPLETED
     input logic flush_i,
     // TO_BE_COMPLETED - TO_BE_COMPLETED
@@ -328,17 +331,9 @@ module load_store_unit
     assign dtlb_ppn                            = mmu_vaddr_plen[riscv::PLEN-1:12];
     assign dtlb_hit                            = 1'b1;
 
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (~rst_ni) begin
-        mmu_paddr         <= '0;
-        translation_valid <= '0;
-        mmu_exception     <= '0;
-      end else begin
-        mmu_paddr         <= mmu_vaddr_plen;
-        translation_valid <= translation_req;
-        mmu_exception     <= misaligned_exception;
-      end
-    end
+    `FFARNC(mmu_paddr        , mmu_vaddr_plen      , clear_i, '0, clk_i, rst_ni)
+    `FFARNC(translation_valid, translation_req     , clear_i, '0, clk_i, rst_ni)
+    `FFARNC(mmu_exception    , misaligned_exception, clear_i, '0, clk_i, rst_ni)
   end
 
 
@@ -351,6 +346,7 @@ module load_store_unit
   ) i_store_unit (
       .clk_i,
       .rst_ni,
+      .clear_i,
       .flush_i,
       .stall_st_pending_i,
       .no_st_pending_o,

--- a/core/lsu_bypass.sv
+++ b/core/lsu_bypass.sv
@@ -23,6 +23,9 @@
 // the LSU control should sample it and store it for later application to the units. It does so, by storing it in a
 // two element FIFO. This is necessary as we only know very late in the cycle whether the load/store will succeed (address check,
 // TLB hit mainly). So we better unconditionally allow another request to arrive and store this request in case we need to.
+
+`include "common_cells/registers.svh"
+
 module lsu_bypass
   import ariane_pkg::*;
 #(
@@ -114,18 +117,9 @@ module lsu_bypass
   end
 
   // registers
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      mem_q           <= '0;
-      status_cnt_q    <= '0;
-      write_pointer_q <= '0;
-      read_pointer_q  <= '0;
-    end else begin
-      mem_q           <= mem_n;
-      status_cnt_q    <= status_cnt_n;
-      write_pointer_q <= write_pointer_n;
-      read_pointer_q  <= read_pointer_n;
-    end
-  end
+  `FFARNC(mem_q           , mem_n          , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(status_cnt_q    , status_cnt_n   , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(write_pointer_q , write_pointer_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(read_pointer_q  , read_pointer_n , 1'b0, '0, clk_i, rst_ni)
 endmodule
 

--- a/core/lsu_bypass.sv
+++ b/core/lsu_bypass.sv
@@ -117,9 +117,9 @@ module lsu_bypass
   end
 
   // registers
-  `FFARNC(mem_q           , mem_n          , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(status_cnt_q    , status_cnt_n   , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(write_pointer_q , write_pointer_n, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(read_pointer_q  , read_pointer_n , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(mem_q, mem_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(status_cnt_q, status_cnt_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(write_pointer_q, write_pointer_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(read_pointer_q, read_pointer_n, 1'b0, '0, clk_i, rst_ni)
 endmodule
 

--- a/core/lsu_bypass.sv
+++ b/core/lsu_bypass.sv
@@ -35,6 +35,8 @@ module lsu_bypass
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // TO_BE_COMPLETED - TO_BE_COMPLETED
     input logic flush_i,
 
@@ -117,9 +119,9 @@ module lsu_bypass
   end
 
   // registers
-  `FFARNC(mem_q, mem_n, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(status_cnt_q, status_cnt_n, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(write_pointer_q, write_pointer_n, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(read_pointer_q, read_pointer_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(mem_q, mem_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(status_cnt_q, status_cnt_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(write_pointer_q, write_pointer_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(read_pointer_q, read_pointer_n, clear_i, '0, clk_i, rst_ni)
 endmodule
 

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -38,6 +38,7 @@ module cva6_mmu_sv32
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     input logic flush_i,
     input logic enable_translation_i,
     input logic en_ld_st_translation_i,  // enable virtual memory translation for load/stores
@@ -566,11 +567,11 @@ module cva6_mmu_sv32
   // ----------
   // Registers
   // ----------
-  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(lsu_req_q       ,lsu_req_n      , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(misaligned_ex_q ,misaligned_ex_n, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_4M_q    ,dtlb_is_4M_n   , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q       ,lsu_req_n      , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(misaligned_ex_q ,misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_4M_q    ,dtlb_is_4M_n   , clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -122,7 +122,7 @@ module cva6_mmu_sv32
   ) i_itlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .clear_i (clear_i),
+      .clear_i(clear_i),
       .flush_i(flush_tlb_i),
 
       .update_i(update_itlb),
@@ -571,11 +571,11 @@ module cva6_mmu_sv32
   // ----------
   // Registers
   // ----------
-  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_req_q       ,lsu_req_n      , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(misaligned_ex_q ,misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_4M_q    ,dtlb_is_4M_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_vaddr_q, lsu_vaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q, lsu_req_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(misaligned_ex_q, misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q, dtlb_pte_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q, dtlb_hit_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q, lsu_is_store_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_4M_q, dtlb_is_4M_n, clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -122,6 +122,7 @@ module cva6_mmu_sv32
   ) i_itlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
+      .clear_i (clear_i),
       .flush_i(flush_tlb_i),
 
       .update_i(update_itlb),
@@ -144,6 +145,7 @@ module cva6_mmu_sv32
   ) i_dtlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
+      .clear_i(clear_i),
       .flush_i(flush_tlb_i),
 
       .update_i(update_dtlb),
@@ -167,6 +169,7 @@ module cva6_mmu_sv32
   ) i_shared_tlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
+      .clear_i(clear_i),
       .flush_i(flush_tlb_i),
 
       .enable_translation_i  (enable_translation_i),
@@ -206,6 +209,7 @@ module cva6_mmu_sv32
   ) i_ptw (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
+      .clear_i(clear_i),
       .flush_i(flush_i),
 
       .ptw_active_o          (ptw_active),

--- a/core/mmu_sv32/cva6_mmu_sv32.sv
+++ b/core/mmu_sv32/cva6_mmu_sv32.sv
@@ -26,6 +26,8 @@
 // 2020-02-17  0.1      S.Jacq       MMU Sv32 for CV32A6
 // =========================================================================== //
 
+`include "common_cells/registers.svh"
+
 module cva6_mmu_sv32
   import ariane_pkg::*;
 #(
@@ -564,23 +566,11 @@ module cva6_mmu_sv32
   // ----------
   // Registers
   // ----------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      lsu_vaddr_q     <= '0;
-      lsu_req_q       <= '0;
-      misaligned_ex_q <= '0;
-      dtlb_pte_q      <= '0;
-      dtlb_hit_q      <= '0;
-      lsu_is_store_q  <= '0;
-      dtlb_is_4M_q    <= '0;
-    end else begin
-      lsu_vaddr_q     <= lsu_vaddr_n;
-      lsu_req_q       <= lsu_req_n;
-      misaligned_ex_q <= misaligned_ex_n;
-      dtlb_pte_q      <= dtlb_pte_n;
-      dtlb_hit_q      <= dtlb_hit_n;
-      lsu_is_store_q  <= lsu_is_store_n;
-      dtlb_is_4M_q    <= dtlb_is_4M_n;
-    end
-  end
+  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q       ,lsu_req_n      , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(misaligned_ex_q ,misaligned_ex_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_4M_q    ,dtlb_is_4M_n   , 1'b0, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv32/cva6_ptw_sv32.sv
+++ b/core/mmu_sv32/cva6_ptw_sv32.sv
@@ -26,6 +26,8 @@
 
 /* verilator lint_off WIDTH */
 
+`include "common_cells/registers.svh"
+
 module cva6_ptw_sv32
   import ariane_pkg::*;
 #(
@@ -370,31 +372,16 @@ module cva6_ptw_sv32
   end
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      state_q           <= IDLE;
-      is_instr_ptw_q    <= 1'b0;
-      ptw_lvl_q         <= LVL1;
-      tag_valid_q       <= 1'b0;
-      tlb_update_asid_q <= '0;
-      vaddr_q           <= '0;
-      ptw_pptr_q        <= '0;
-      global_mapping_q  <= 1'b0;
-      data_rdata_q      <= '0;
-      data_rvalid_q     <= 1'b0;
-    end else begin
-      state_q           <= state_d;
-      ptw_pptr_q        <= ptw_pptr_n;
-      is_instr_ptw_q    <= is_instr_ptw_n;
-      ptw_lvl_q         <= ptw_lvl_n;
-      tag_valid_q       <= tag_valid_n;
-      tlb_update_asid_q <= tlb_update_asid_n;
-      vaddr_q           <= vaddr_n;
-      global_mapping_q  <= global_mapping_n;
-      data_rdata_q      <= req_port_i.data_rdata;
-      data_rvalid_q     <= req_port_i.data_rvalid;
-    end
-  end
+  `FFARNC(state_q           , state_d               , 1'b0, IDLE, clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , 1'b0, 1'b0, clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , 1'b0, LVL1, clk_i, rst_ni)
+  `FFARNC(tag_valid_q       , tag_valid_n           , 1'b0, 1'b0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(vaddr_q           , vaddr_n               , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(global_mapping_q  , global_mapping_n      , 1'b0, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rdata_q      , req_port_i.data_rdata , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, 1'b0, 1'b0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv32/cva6_ptw_sv32.sv
+++ b/core/mmu_sv32/cva6_ptw_sv32.sv
@@ -375,14 +375,14 @@ module cva6_ptw_sv32
   // sequential process
   `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
   `FFARNC(ptw_pptr_q, ptw_pptr_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(ptw_lvl_q, ptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
-  `FFARNC(tag_valid_q, tag_valid_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tag_valid_q, tag_valid_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(tlb_update_asid_q, tlb_update_asid_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(vaddr_q, vaddr_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(global_mapping_q, global_mapping_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(global_mapping_q, global_mapping_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(data_rdata_q, req_port_i.data_rdata, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, '0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv32/cva6_ptw_sv32.sv
+++ b/core/mmu_sv32/cva6_ptw_sv32.sv
@@ -36,6 +36,7 @@ module cva6_ptw_sv32
 ) (
     input  logic clk_i,                  // Clock
     input  logic rst_ni,                 // Asynchronous reset active low
+    input  logic clear_i,
     input  logic flush_i,                // flush everything, we need to do this because
                                          // actually everything we do is speculative at this stage
                                          // e.g.: there could be a CSR instruction that changes everything
@@ -372,16 +373,16 @@ module cva6_ptw_sv32
   end
 
   // sequential process
-  `FFARNC(state_q           , state_d               , 1'b0, IDLE, clk_i, rst_ni)
-  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , 1'b0, 1'b0, clk_i, rst_ni)
-  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , 1'b0, LVL1, clk_i, rst_ni)
-  `FFARNC(tag_valid_q       , tag_valid_n           , 1'b0, 1'b0, clk_i, rst_ni)
-  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(vaddr_q           , vaddr_n               , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(global_mapping_q  , global_mapping_n      , 1'b0, 1'b0, clk_i, rst_ni)
-  `FFARNC(data_rdata_q      , req_port_i.data_rdata , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, 1'b0, 1'b0, clk_i, rst_ni)
+  `FFARNC(state_q           , state_d               , clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , clear_i, '0  , clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , clear_i, LVL1, clk_i, rst_ni)
+  `FFARNC(tag_valid_q       , tag_valid_n           , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , clear_i, '0  , clk_i, rst_ni)
+  `FFARNC(vaddr_q           , vaddr_n               , clear_i, '0  , clk_i, rst_ni)
+  `FFARNC(global_mapping_q  , global_mapping_n      , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rdata_q      , req_port_i.data_rdata , clear_i, '0  , clk_i, rst_ni)
+  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv32/cva6_ptw_sv32.sv
+++ b/core/mmu_sv32/cva6_ptw_sv32.sv
@@ -373,16 +373,16 @@ module cva6_ptw_sv32
   end
 
   // sequential process
-  `FFARNC(state_q           , state_d               , clear_i, IDLE, clk_i, rst_ni)
-  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , clear_i, '0  , clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , clear_i, LVL1, clk_i, rst_ni)
-  `FFARNC(tag_valid_q       , tag_valid_n           , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , clear_i, '0  , clk_i, rst_ni)
-  `FFARNC(vaddr_q           , vaddr_n               , clear_i, '0  , clk_i, rst_ni)
-  `FFARNC(global_mapping_q  , global_mapping_n      , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(data_rdata_q      , req_port_i.data_rdata , clear_i, '0  , clk_i, rst_ni)
-  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q, ptw_pptr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q, ptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
+  `FFARNC(tag_valid_q, tag_valid_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q, tlb_update_asid_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vaddr_q, vaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(global_mapping_q, global_mapping_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rdata_q, req_port_i.data_rdata, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_shared_tlb_sv32.sv
@@ -232,17 +232,17 @@ module cva6_shared_tlb_sv32
   end  //tag_comparison
 
   // sequential process
-  `FFARNC(itlb_vpn_q          , itlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(dtlb_vpn_q          , dtlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(tlb_update_asid_q   , tlb_update_asid_d              , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(shared_tlb_access_q , shared_tlb_access_d            , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(shared_tlb_vaddr_q  , shared_tlb_vaddr_d             , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(shared_tag_valid_q  , shared_tag_valid_d             , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(vpn0_q              , vpn0_d                         , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(vpn1_q              , vpn1_d                         , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(itlb_req_q          , itlb_req_d                     , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(dtlb_req_q          , dtlb_req_d                     , clear_i, '0, clk_i, rstn_i)
-  `FFARNC(shared_tag_valid    , shared_tag_valid_q[tag_rd_addr], clear_i, '0, clk_i, rstn_i)
+  `FFARNC(itlb_vpn_q          , itlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_vpn_q          , dtlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q   , tlb_update_asid_d              , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tlb_access_q , shared_tlb_access_d            , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tlb_vaddr_q  , shared_tlb_vaddr_d             , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tag_valid_q  , shared_tag_valid_d             , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vpn0_q              , vpn0_d                         , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vpn1_q              , vpn1_d                         , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(itlb_req_q          , itlb_req_d                     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_req_q          , dtlb_req_d                     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tag_valid    , shared_tag_valid_q[tag_rd_addr], clear_i, '0, clk_i, rst_ni)
 
   // ------------------
   // Update and Flush

--- a/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_shared_tlb_sv32.sv
@@ -17,6 +17,8 @@
 
 /* verilator lint_off WIDTH */
 
+`include "common_cells/registers.svh"
+
 module cva6_shared_tlb_sv32
   import ariane_pkg::*;
 #(
@@ -229,33 +231,17 @@ module cva6_shared_tlb_sv32
   end  //tag_comparison
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      itlb_vpn_q <= '0;
-      dtlb_vpn_q <= '0;
-      tlb_update_asid_q <= '0;
-      shared_tlb_access_q <= '0;
-      shared_tlb_vaddr_q <= '0;
-      shared_tag_valid_q <= '0;
-      vpn0_q <= '0;
-      vpn1_q <= '0;
-      itlb_req_q <= '0;
-      dtlb_req_q <= '0;
-      shared_tag_valid <= '0;
-    end else begin
-      itlb_vpn_q <= itlb_vaddr_i[riscv::SV-1:12];
-      dtlb_vpn_q <= dtlb_vaddr_i[riscv::SV-1:12];
-      tlb_update_asid_q <= tlb_update_asid_d;
-      shared_tlb_access_q <= shared_tlb_access_d;
-      shared_tlb_vaddr_q <= shared_tlb_vaddr_d;
-      shared_tag_valid_q <= shared_tag_valid_d;
-      vpn0_q <= vpn0_d;
-      vpn1_q <= vpn1_d;
-      itlb_req_q <= itlb_req_d;
-      dtlb_req_q <= dtlb_req_d;
-      shared_tag_valid <= shared_tag_valid_q[tag_rd_addr];
-    end
-  end
+  `FFARNC(itlb_vpn_q          , itlb_vaddr_i[riscv::SV-1:12]   , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(dtlb_vpn_q          , dtlb_vaddr_i[riscv::SV-1:12]   , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(tlb_update_asid_q   , tlb_update_asid_d              , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(shared_tlb_access_q , shared_tlb_access_d            , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(shared_tlb_vaddr_q  , shared_tlb_vaddr_d             , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(shared_tag_valid_q  , shared_tag_valid_d             , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(vpn0_q              , vpn0_d                         , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(vpn1_q              , vpn1_d                         , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(itlb_req_q          , itlb_req_d                     , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(dtlb_req_q          , dtlb_req_d                     , 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(shared_tag_valid    , shared_tag_valid_q[tag_rd_addr], 1'b0, '0, clk_i, rstn_i)
 
   // ------------------
   // Update and Flush

--- a/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_shared_tlb_sv32.sv
@@ -27,10 +27,10 @@ module cva6_shared_tlb_sv32
     parameter int SHARED_TLB_WAYS = 2,
     parameter int ASID_WIDTH = 1
 ) (
-    input logic clk_i,   // Clock
+    input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
-    input logic clear_i,
     input logic flush_i,
+    input logic clear_i,
 
     input logic enable_translation_i,   // CSRs indicate to enable SV32
     input logic en_ld_st_translation_i, // enable virtual memory translation for load/stores
@@ -232,17 +232,17 @@ module cva6_shared_tlb_sv32
   end  //tag_comparison
 
   // sequential process
-  `FFARNC(itlb_vpn_q          , itlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_vpn_q          , dtlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(tlb_update_asid_q   , tlb_update_asid_d              , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(shared_tlb_access_q , shared_tlb_access_d            , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(shared_tlb_vaddr_q  , shared_tlb_vaddr_d             , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(shared_tag_valid_q  , shared_tag_valid_d             , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(vpn0_q              , vpn0_d                         , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(vpn1_q              , vpn1_d                         , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(itlb_req_q          , itlb_req_d                     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_req_q          , dtlb_req_d                     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(shared_tag_valid    , shared_tag_valid_q[tag_rd_addr], clear_i, '0, clk_i, rst_ni)
+  `FFARNC(itlb_vpn_q, itlb_vaddr_i[riscv::SV-1:12], clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_vpn_q, dtlb_vaddr_i[riscv::SV-1:12], clear_i, '0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q, tlb_update_asid_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tlb_access_q, shared_tlb_access_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tlb_vaddr_q, shared_tlb_vaddr_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tag_valid_q, shared_tag_valid_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vpn0_q, vpn0_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vpn1_q, vpn1_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(itlb_req_q, itlb_req_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_req_q, dtlb_req_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(shared_tag_valid, shared_tag_valid_q[tag_rd_addr], clear_i, '0, clk_i, rst_ni)
 
   // ------------------
   // Update and Flush

--- a/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_shared_tlb_sv32.sv
@@ -29,6 +29,7 @@ module cva6_shared_tlb_sv32
 ) (
     input logic clk_i,   // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,
     input logic flush_i,
 
     input logic enable_translation_i,   // CSRs indicate to enable SV32
@@ -231,17 +232,17 @@ module cva6_shared_tlb_sv32
   end  //tag_comparison
 
   // sequential process
-  `FFARNC(itlb_vpn_q          , itlb_vaddr_i[riscv::SV-1:12]   , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(dtlb_vpn_q          , dtlb_vaddr_i[riscv::SV-1:12]   , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(tlb_update_asid_q   , tlb_update_asid_d              , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(shared_tlb_access_q , shared_tlb_access_d            , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(shared_tlb_vaddr_q  , shared_tlb_vaddr_d             , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(shared_tag_valid_q  , shared_tag_valid_d             , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(vpn0_q              , vpn0_d                         , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(vpn1_q              , vpn1_d                         , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(itlb_req_q          , itlb_req_d                     , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(dtlb_req_q          , dtlb_req_d                     , 1'b0, '0, clk_i, rstn_i)
-  `FFARNC(shared_tag_valid    , shared_tag_valid_q[tag_rd_addr], 1'b0, '0, clk_i, rstn_i)
+  `FFARNC(itlb_vpn_q          , itlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(dtlb_vpn_q          , dtlb_vaddr_i[riscv::SV-1:12]   , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(tlb_update_asid_q   , tlb_update_asid_d              , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(shared_tlb_access_q , shared_tlb_access_d            , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(shared_tlb_vaddr_q  , shared_tlb_vaddr_d             , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(shared_tag_valid_q  , shared_tag_valid_d             , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(vpn0_q              , vpn0_d                         , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(vpn1_q              , vpn1_d                         , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(itlb_req_q          , itlb_req_d                     , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(dtlb_req_q          , dtlb_req_d                     , clear_i, '0, clk_i, rstn_i)
+  `FFARNC(shared_tag_valid    , shared_tag_valid_q[tag_rd_addr], clear_i, '0, clk_i, rstn_i)
 
   // ------------------
   // Update and Flush

--- a/core/mmu_sv32/cva6_shared_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_shared_tlb_sv32.sv
@@ -27,8 +27,8 @@ module cva6_shared_tlb_sv32
     parameter int SHARED_TLB_WAYS = 2,
     parameter int ASID_WIDTH = 1
 ) (
-    input logic clk_i,  // Clock
-    input logic rst_ni,  // Asynchronous reset active low
+    input logic clk_i,
+    input logic rst_ni,
     input logic flush_i,
     input logic clear_i,
 

--- a/core/mmu_sv32/cva6_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_tlb_sv32.sv
@@ -24,6 +24,8 @@
 // 2020-02-17  0.1      S.Jacq       TLB Sv32 for CV32A6
 // =========================================================================== //
 
+`include "common_cells/registers.svh"
+
 module cva6_tlb_sv32
   import ariane_pkg::*;
 #(
@@ -224,18 +226,11 @@ module cva6_tlb_sv32
   end
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      tags_q      <= '{default: 0};
-      content_q   <= '{default: 0};
-      plru_tree_q <= '{default: 0};
-    end else begin
-      tags_q      <= tags_n;
-      content_q   <= content_n;
-      plru_tree_q <= plru_tree_n;
-    end
-  end
-  //--------------
+  `FFARNC(tags_q      ,tags_n     , 1'b0, '{defautl: 0}, clk_i, rst_ni)
+  `FFARNC(content_q   ,content_n  , 1'b0, '{defautl: 0}, clk_i, rst_ni)
+  `FFARNC(plru_tree_q ,plru_tree_n, 1'b0, '{defautl: 0}, clk_i, rst_ni)
+
+ //--------------
   // Sanity checks
   //--------------
 

--- a/core/mmu_sv32/cva6_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_tlb_sv32.sv
@@ -35,6 +35,7 @@ module cva6_tlb_sv32
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,
     input logic flush_i,  // Flush signal
     // Update TLB
     input tlb_update_sv32_t update_i,
@@ -226,9 +227,9 @@ module cva6_tlb_sv32
   end
 
   // sequential process
-  `FFARNC(tags_q      ,tags_n     , 1'b0, '{defautl: 0}, clk_i, rst_ni)
-  `FFARNC(content_q   ,content_n  , 1'b0, '{defautl: 0}, clk_i, rst_ni)
-  `FFARNC(plru_tree_q ,plru_tree_n, 1'b0, '{defautl: 0}, clk_i, rst_ni)
+  `FFARNC(tags_q      ,tags_n     , clear_i, '{defautl: 0}, clk_i, rst_ni)
+  `FFARNC(content_q   ,content_n  , clear_i, '{defautl: 0}, clk_i, rst_ni)
+  `FFARNC(plru_tree_q ,plru_tree_n, clear_i, '{defautl: 0}, clk_i, rst_ni)
 
  //--------------
   // Sanity checks

--- a/core/mmu_sv32/cva6_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_tlb_sv32.sv
@@ -227,9 +227,9 @@ module cva6_tlb_sv32
   end
 
   // sequential process
-  `FFARNC(tags_q, tags_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(content_q, content_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(plru_tree_q, plru_tree_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(tags_q, tags_n, clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(content_q, content_n, clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(plru_tree_q, plru_tree_n, clear_i, '{default: 0}, clk_i, rst_ni)
 
   //--------------
   // Sanity checks

--- a/core/mmu_sv32/cva6_tlb_sv32.sv
+++ b/core/mmu_sv32/cva6_tlb_sv32.sv
@@ -227,11 +227,11 @@ module cva6_tlb_sv32
   end
 
   // sequential process
-  `FFARNC(tags_q      ,tags_n     , clear_i, '{defautl: 0}, clk_i, rst_ni)
-  `FFARNC(content_q   ,content_n  , clear_i, '{defautl: 0}, clk_i, rst_ni)
-  `FFARNC(plru_tree_q ,plru_tree_n, clear_i, '{defautl: 0}, clk_i, rst_ni)
+  `FFARNC(tags_q, tags_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(content_q, content_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(plru_tree_q, plru_tree_n, clear_i, '0, clk_i, rst_ni)
 
- //--------------
+  //--------------
   // Sanity checks
   //--------------
 

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -14,6 +14,7 @@
 //              address translation unit. SV39 as defined in RISC-V
 //              privilege specification 1.11-WIP
 
+`include "common_cells/registers.svh"
 
 module mmu
   import ariane_pkg::*;
@@ -25,6 +26,7 @@ module mmu
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     input logic flush_i,
     input logic enable_translation_i,
     input logic en_ld_st_translation_i,  // enable virtual memory translation for load/stores
@@ -510,25 +512,12 @@ module mmu
   // ----------
   // Registers
   // ----------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      lsu_vaddr_q     <= '0;
-      lsu_req_q       <= '0;
-      misaligned_ex_q <= '0;
-      dtlb_pte_q      <= '0;
-      dtlb_hit_q      <= '0;
-      lsu_is_store_q  <= '0;
-      dtlb_is_2M_q    <= '0;
-      dtlb_is_1G_q    <= '0;
-    end else begin
-      lsu_vaddr_q     <= lsu_vaddr_n;
-      lsu_req_q       <= lsu_req_n;
-      misaligned_ex_q <= misaligned_ex_n;
-      dtlb_pte_q      <= dtlb_pte_n;
-      dtlb_hit_q      <= dtlb_hit_n;
-      lsu_is_store_q  <= lsu_is_store_n;
-      dtlb_is_2M_q    <= dtlb_is_2M_n;
-      dtlb_is_1G_q    <= dtlb_is_1G_n;
-    end
-  end
+  `FFARNC(lsu_vaddr_q    , lsu_vaddr_n    , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q      , lsu_req_n      , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(misaligned_ex_q, misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q     , dtlb_pte_n     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q     , dtlb_hit_n     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q , lsu_is_store_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_2M_q   , dtlb_is_2M_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_1G_q   , dtlb_is_1G_n   , clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -106,6 +106,7 @@ module mmu
   ) i_itlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
+      .clear_i (clear_i),
       .flush_i(flush_tlb_i),
 
       .update_i(update_ptw_itlb),
@@ -129,6 +130,7 @@ module mmu
   ) i_dtlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
+      .clear_i (clear_i)
       .flush_i(flush_tlb_i),
 
       .update_i(update_ptw_dtlb),
@@ -152,6 +154,7 @@ module mmu
   ) i_ptw (
       .clk_i                 (clk_i),
       .rst_ni                (rst_ni),
+      .clear_i               (clear_i),
       .ptw_active_o          (ptw_active),
       .walking_instr_o       (walking_instr),
       .ptw_error_o           (ptw_error),

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -106,7 +106,7 @@ module mmu
   ) i_itlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .clear_i (clear_i),
+      .clear_i(clear_i),
       .flush_i(flush_tlb_i),
 
       .update_i(update_ptw_itlb),
@@ -515,12 +515,12 @@ module mmu
   // ----------
   // Registers
   // ----------
-  `FFARNC(lsu_vaddr_q    , lsu_vaddr_n    , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_req_q      , lsu_req_n      , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_vaddr_q, lsu_vaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q, lsu_req_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(misaligned_ex_q, misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_pte_q     , dtlb_pte_n     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_hit_q     , dtlb_hit_n     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_is_store_q , lsu_is_store_n , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_2M_q   , dtlb_is_2M_n   , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_1G_q   , dtlb_is_1G_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q, dtlb_pte_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q, dtlb_hit_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q, lsu_is_store_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_2M_q, dtlb_is_2M_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_1G_q, dtlb_is_1G_n, clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv39/mmu.sv
+++ b/core/mmu_sv39/mmu.sv
@@ -130,7 +130,7 @@ module mmu
   ) i_dtlb (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .clear_i (clear_i)
+      .clear_i(clear_i),
       .flush_i(flush_tlb_i),
 
       .update_i(update_ptw_dtlb),

--- a/core/mmu_sv39/ptw.sv
+++ b/core/mmu_sv39/ptw.sv
@@ -383,15 +383,15 @@ module ptw
 
   // sequential process
   `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
-  `FFARNC(ptw_pptr_q, ptw_pptr_n, clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q, ptw_pptr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(ptw_lvl_q, ptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
-  `FFARNC(tag_valid_q, tag_valid_n, clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(tlb_update_asid_q, tlb_update_asid_n, clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(vaddr_q, vaddr_n, clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(global_mapping_q, global_mapping_n, clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(data_rdata_q, req_port_i.data_rdata, clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tag_valid_q, tag_valid_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q, tlb_update_asid_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vaddr_q, vaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(global_mapping_q, global_mapping_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(data_rdata_q, req_port_i.data_rdata, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, '0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv39/ptw.sv
+++ b/core/mmu_sv39/ptw.sv
@@ -382,16 +382,16 @@ module ptw
   end
 
   // sequential process
-  `FFARNC(state_q          , state_d               , clear_i, IDLE, clk_i, rst_ni)
-  `FFARNC(ptw_pptr_q       , ptw_pptr_n            , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q   , is_instr_ptw_n        , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(ptw_lvl_q        , ptw_lvl_n             , clear_i, LVL1, clk_i, rst_ni)
-  `FFARNC(tag_valid_q      , tag_valid_n           , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(tlb_update_asid_q, tlb_update_asid_n     , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(vaddr_q          , vaddr_n               , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(global_mapping_q , global_mapping_n      , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(data_rdata_q     , req_port_i.data_rdata , clear_i, 1'b0, clk_i, rst_ni)
-  `FFARNC(data_rvalid_q    , req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q, ptw_pptr_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q, ptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
+  `FFARNC(tag_valid_q, tag_valid_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q, tlb_update_asid_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(vaddr_q, vaddr_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(global_mapping_q, global_mapping_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rdata_q, req_port_i.data_rdata, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv39/ptw.sv
+++ b/core/mmu_sv39/ptw.sv
@@ -15,6 +15,8 @@
 
 /* verilator lint_off WIDTH */
 
+`include "common_cells/registers.svh"
+
 module ptw
   import ariane_pkg::*;
 #(
@@ -23,6 +25,7 @@ module ptw
 ) (
     input  logic clk_i,                   // Clock
     input  logic rst_ni,                  // Asynchronous reset active low
+    input  logic clear_i,
     input  logic flush_i,                 // flush everything, we need to do this because
                                           // actually everything we do is speculative at this stage
                                           // e.g.: there could be a CSR instruction that changes everything
@@ -379,31 +382,16 @@ module ptw
   end
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      state_q           <= IDLE;
-      is_instr_ptw_q    <= 1'b0;
-      ptw_lvl_q         <= LVL1;
-      tag_valid_q       <= 1'b0;
-      tlb_update_asid_q <= '0;
-      vaddr_q           <= '0;
-      ptw_pptr_q        <= '0;
-      global_mapping_q  <= 1'b0;
-      data_rdata_q      <= '0;
-      data_rvalid_q     <= 1'b0;
-    end else begin
-      state_q           <= state_d;
-      ptw_pptr_q        <= ptw_pptr_n;
-      is_instr_ptw_q    <= is_instr_ptw_n;
-      ptw_lvl_q         <= ptw_lvl_n;
-      tag_valid_q       <= tag_valid_n;
-      tlb_update_asid_q <= tlb_update_asid_n;
-      vaddr_q           <= vaddr_n;
-      global_mapping_q  <= global_mapping_n;
-      data_rdata_q      <= req_port_i.data_rdata;
-      data_rvalid_q     <= req_port_i.data_rvalid;
-    end
-  end
+  `FFARNC(state_q          , state_d               , clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q       , ptw_pptr_n            , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q   , is_instr_ptw_n        , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q        , ptw_lvl_n             , clear_i, LVL1, clk_i, rst_ni)
+  `FFARNC(tag_valid_q      , tag_valid_n           , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q, tlb_update_asid_n     , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(vaddr_q          , vaddr_n               , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(global_mapping_q , global_mapping_n      , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rdata_q     , req_port_i.data_rdata , clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rvalid_q    , req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv39/tlb.sv
+++ b/core/mmu_sv39/tlb.sv
@@ -14,6 +14,7 @@
 // Description: Translation Lookaside Buffer, SV39
 //              fully set-associative
 
+`include "common_cells/registers.svh"
 
 module tlb
   import ariane_pkg::*;
@@ -24,6 +25,7 @@ module tlb
 ) (
     input  logic                          clk_i,                  // Clock
     input  logic                          rst_ni,                 // Asynchronous reset active low
+    input  logic                          clear_i,
     input  logic                          flush_i,                // Flush signal
     // Update TLB
     input  tlb_update_t                   update_i,
@@ -233,17 +235,9 @@ module tlb
   end
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      tags_q      <= '{default: 0};
-      content_q   <= '{default: 0};
-      plru_tree_q <= '{default: 0};
-    end else begin
-      tags_q      <= tags_n;
-      content_q   <= content_n;
-      plru_tree_q <= plru_tree_n;
-    end
-  end
+  `FFARNC(tags_q     , tags_n     , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(content_q  , content_n  , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(plru_tree_q, plru_tree_n, clear_i, '{default: 0}, clk_i, rst_ni)
   //--------------
   // Sanity checks
   //--------------

--- a/core/mmu_sv39/tlb.sv
+++ b/core/mmu_sv39/tlb.sv
@@ -235,8 +235,8 @@ module tlb
   end
 
   // sequential process
-  `FFARNC(tags_q     , tags_n     , clear_i, '{default: 0}, clk_i, rst_ni)
-  `FFARNC(content_q  , content_n  , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(tags_q, tags_n, clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(content_q, content_n, clear_i, '{default: 0}, clk_i, rst_ni)
   `FFARNC(plru_tree_q, plru_tree_n, clear_i, '{default: 0}, clk_i, rst_ni)
   //--------------
   // Sanity checks

--- a/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
@@ -687,16 +687,16 @@ module cva6_mmu_sv39x4
   // ----------
   // Registers
   // ----------
-  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_gpaddr_q    ,lsu_gpaddr_n   , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_tinst_q     ,lsu_tinst_n    , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(hs_ld_st_inst_q ,hs_ld_st_inst_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_req_q       ,lsu_req_n      , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(misaligned_ex_q ,misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_gpte_q     ,dtlb_gpte_n    , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_2M_q    ,dtlb_is_2M_n   , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_1G_q    ,dtlb_is_1G_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_vaddr_q, lsu_vaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_gpaddr_q, lsu_gpaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_tinst_q, lsu_tinst_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(hs_ld_st_inst_q, hs_ld_st_inst_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q, lsu_req_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(misaligned_ex_q, misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q, dtlb_pte_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_gpte_q, dtlb_gpte_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q, dtlb_hit_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q, lsu_is_store_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_2M_q, dtlb_is_2M_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_1G_q, dtlb_is_1G_n, clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
@@ -18,6 +18,7 @@
 //              This module is an adaptation of the MMU Sv39x4 developed
 //              by Florian Zaruba to the Sv39x4 standard.
 
+`include "common_cells/registers.svh"
 
 module cva6_mmu_sv39x4
   import ariane_pkg::*;
@@ -683,33 +684,16 @@ module cva6_mmu_sv39x4
   // ----------
   // Registers
   // ----------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      lsu_vaddr_q     <= '0;
-      lsu_gpaddr_q    <= '0;
-      lsu_tinst_q     <= '0;
-      hs_ld_st_inst_q <= '0;
-      lsu_req_q       <= '0;
-      misaligned_ex_q <= '0;
-      dtlb_pte_q      <= '0;
-      dtlb_gpte_q     <= '0;
-      dtlb_hit_q      <= '0;
-      lsu_is_store_q  <= '0;
-      dtlb_is_2M_q    <= '0;
-      dtlb_is_1G_q    <= '0;
-    end else begin
-      lsu_vaddr_q     <= lsu_vaddr_n;
-      lsu_gpaddr_q    <= lsu_gpaddr_n;
-      lsu_tinst_q     <= lsu_tinst_n;
-      hs_ld_st_inst_q <= hs_ld_st_inst_n;
-      lsu_req_q       <= lsu_req_n;
-      misaligned_ex_q <= misaligned_ex_n;
-      dtlb_pte_q      <= dtlb_pte_n;
-      dtlb_gpte_q     <= dtlb_gpte_n;
-      dtlb_hit_q      <= dtlb_hit_n;
-      lsu_is_store_q  <= lsu_is_store_n;
-      dtlb_is_2M_q    <= dtlb_is_2M_n;
-      dtlb_is_1G_q    <= dtlb_is_1G_n;
-    end
-  end
+  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_gpaddr_q    ,lsu_gpaddr_n   , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_tinst_q     ,lsu_tinst_n    , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(hs_ld_st_inst_q ,hs_ld_st_inst_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q       ,lsu_req_n      , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(misaligned_ex_q ,misaligned_ex_n, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_gpte_q     ,dtlb_gpte_n    , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_2M_q    ,dtlb_is_2M_n   , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_1G_q    ,dtlb_is_1G_n   , 1'b0, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_mmu_sv39x4.sv
@@ -31,6 +31,7 @@ module cva6_mmu_sv39x4
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     input logic flush_i,
     input logic enable_translation_i,
     input logic enable_g_translation_i,
@@ -143,6 +144,7 @@ module cva6_mmu_sv39x4
   ) i_itlb (
       .clk_i       (clk_i),
       .rst_ni      (rst_ni),
+      .clear_i     (clear_i),
       .flush_i     (flush_tlb_i),
       .flush_vvma_i(flush_tlb_vvma_i),
       .flush_gvma_i(flush_tlb_gvma_i),
@@ -177,6 +179,7 @@ module cva6_mmu_sv39x4
   ) i_dtlb (
       .clk_i       (clk_i),
       .rst_ni      (rst_ni),
+      .clear_i     (clear_i),
       .flush_i     (flush_tlb_i),
       .flush_vvma_i(flush_tlb_vvma_i),
       .flush_gvma_i(flush_tlb_gvma_i),
@@ -684,16 +687,16 @@ module cva6_mmu_sv39x4
   // ----------
   // Registers
   // ----------
-  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(lsu_gpaddr_q    ,lsu_gpaddr_n   , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(lsu_tinst_q     ,lsu_tinst_n    , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(hs_ld_st_inst_q ,hs_ld_st_inst_n, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(lsu_req_q       ,lsu_req_n      , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(misaligned_ex_q ,misaligned_ex_n, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_gpte_q     ,dtlb_gpte_n    , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_2M_q    ,dtlb_is_2M_n   , 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(dtlb_is_1G_q    ,dtlb_is_1G_n   , 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(lsu_vaddr_q     ,lsu_vaddr_n    , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_gpaddr_q    ,lsu_gpaddr_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_tinst_q     ,lsu_tinst_n    , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(hs_ld_st_inst_q ,hs_ld_st_inst_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_req_q       ,lsu_req_n      , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(misaligned_ex_q ,misaligned_ex_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_pte_q      ,dtlb_pte_n     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_gpte_q     ,dtlb_gpte_n    , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_hit_q      ,dtlb_hit_n     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(lsu_is_store_q  ,lsu_is_store_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_2M_q    ,dtlb_is_2M_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(dtlb_is_1G_q    ,dtlb_is_1G_n   , clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
@@ -30,6 +30,7 @@ module cva6_ptw_sv39x4
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,
     input logic flush_i,  // flush everything, we need to do this because
                           // actually everything we do is speculative at this stage
                           // e.g.: there could be a CSR instruction that changes everything
@@ -598,22 +599,22 @@ module cva6_ptw_sv39x4
   end
 
   // sequential process
-  `FFARNC(state_q           , state_d               , 0    , IDLE   , clk_i, rst_ni)
-  `FFARNC(ptw_stage_q       , ptw_stage_d           , 0    , S_STAGE, clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , 1'b0 , 1'b0   , clk_i, rst_ni)
-  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , 1'b0 , LVL1   , clk_i, rst_ni)
-  `FFARNC(gptw_lvl_q        , gptw_lvl_n            , 1'b0 , LVL1   , clk_i, rst_ni)
-  `FFARNC(tag_valid_q       , tag_valid_n           , 1'b0 , 1'b0   , clk_i, rst_ni)
-  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(tlb_update_vmid_q , tlb_update_vmid_n     , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(vaddr_q           , vaddr_n               , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(gpaddr_q          , gpaddr_n              , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(gptw_pptr_q       , gptw_pptr_n           , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(global_mapping_q  , global_mapping_n      , 1'b0 , 1'b0   , clk_i, rst_ni)
-  `FFARNC(data_rdata_q      , req_port_i.data_rdata , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(gpte_q            , gpte_d                , 1'b0 , '0     , clk_i, rst_ni)
-  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, 1'b0 , 1'b0   , clk_i, rst_ni)
+  `FFARNC(state_q           , state_d               , clear_i, IDLE   , clk_i, rst_ni)
+  `FFARNC(ptw_stage_q       , ptw_stage_d           , clear_i, S_STAGE, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , clear_i, 1'b0   , clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , clear_i, LVL1   , clk_i, rst_ni)
+  `FFARNC(gptw_lvl_q        , gptw_lvl_n            , clear_i, LVL1   , clk_i, rst_ni)
+  `FFARNC(tag_valid_q       , tag_valid_n           , clear_i, 1'b0   , clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(tlb_update_vmid_q , tlb_update_vmid_n     , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(vaddr_q           , vaddr_n               , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(gpaddr_q          , gpaddr_n              , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(gptw_pptr_q       , gptw_pptr_n           , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(global_mapping_q  , global_mapping_n      , clear_i, 1'b0   , clk_i, rst_ni)
+  `FFARNC(data_rdata_q      , req_port_i.data_rdata , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(gpte_q            , gpte_d                , clear_i, '0     , clk_i, rst_ni)
+  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, clear_i, 1'b0   , clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
@@ -19,6 +19,8 @@
 
 /* verilator lint_off WIDTH */
 
+`include "common_cells/registers.svh"
+
 module cva6_ptw_sv39x4
   import ariane_pkg::*;
 #(
@@ -596,43 +598,22 @@ module cva6_ptw_sv39x4
   end
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      state_q           <= IDLE;
-      ptw_stage_q       <= S_STAGE;
-      is_instr_ptw_q    <= 1'b0;
-      ptw_lvl_q         <= LVL1;
-      gptw_lvl_q        <= LVL1;
-      tag_valid_q       <= 1'b0;
-      tlb_update_asid_q <= '0;
-      tlb_update_vmid_q <= '0;
-      vaddr_q           <= '0;
-      gpaddr_q          <= '0;
-      ptw_pptr_q        <= '0;
-      gptw_pptr_q       <= '0;
-      global_mapping_q  <= 1'b0;
-      data_rdata_q      <= '0;
-      gpte_q            <= '0;
-      data_rvalid_q     <= 1'b0;
-    end else begin
-      state_q           <= state_d;
-      ptw_stage_q       <= ptw_stage_d;
-      ptw_pptr_q        <= ptw_pptr_n;
-      gptw_pptr_q       <= gptw_pptr_n;
-      is_instr_ptw_q    <= is_instr_ptw_n;
-      ptw_lvl_q         <= ptw_lvl_n;
-      gptw_lvl_q        <= gptw_lvl_n;
-      tag_valid_q       <= tag_valid_n;
-      tlb_update_asid_q <= tlb_update_asid_n;
-      tlb_update_vmid_q <= tlb_update_vmid_n;
-      vaddr_q           <= vaddr_n;
-      gpaddr_q          <= gpaddr_n;
-      global_mapping_q  <= global_mapping_n;
-      data_rdata_q      <= req_port_i.data_rdata;
-      gpte_q            <= gpte_d;
-      data_rvalid_q     <= req_port_i.data_rvalid;
-    end
-  end
+  `FFARNC(state_q           , state_d               , 0    , IDLE   , clk_i, rst_ni)
+  `FFARNC(ptw_stage_q       , ptw_stage_d           , 0    , S_STAGE, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , 1'b0 , 1'b0   , clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , 1'b0 , LVL1   , clk_i, rst_ni)
+  `FFARNC(gptw_lvl_q        , gptw_lvl_n            , 1'b0 , LVL1   , clk_i, rst_ni)
+  `FFARNC(tag_valid_q       , tag_valid_n           , 1'b0 , 1'b0   , clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(tlb_update_vmid_q , tlb_update_vmid_n     , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(vaddr_q           , vaddr_n               , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(gpaddr_q          , gpaddr_n              , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(gptw_pptr_q       , gptw_pptr_n           , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(global_mapping_q  , global_mapping_n      , 1'b0 , 1'b0   , clk_i, rst_ni)
+  `FFARNC(data_rdata_q      , req_port_i.data_rdata , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(gpte_q            , gpte_d                , 1'b0 , '0     , clk_i, rst_ni)
+  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, 1'b0 , 1'b0   , clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
@@ -601,20 +601,20 @@ module cva6_ptw_sv39x4
   // sequential process
   `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
   `FFARNC(ptw_stage_q, ptw_stage_d, clear_i, S_STAGE, clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(ptw_lvl_q, ptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
   `FFARNC(gptw_lvl_q, gptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
-  `FFARNC(tag_valid_q, tag_valid_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tag_valid_q, tag_valid_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(tlb_update_asid_q, tlb_update_asid_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(tlb_update_vmid_q, tlb_update_vmid_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(vaddr_q, vaddr_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(gpaddr_q, gpaddr_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(ptw_pptr_q, ptw_pptr_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(gptw_pptr_q, gptw_pptr_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(global_mapping_q, global_mapping_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(global_mapping_q, global_mapping_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(data_rdata_q, req_port_i.data_rdata, clear_i, '0, clk_i, rst_ni)
   `FFARNC(gpte_q, gpte_d, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, '0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_ptw_sv39x4.sv
@@ -599,22 +599,22 @@ module cva6_ptw_sv39x4
   end
 
   // sequential process
-  `FFARNC(state_q           , state_d               , clear_i, IDLE   , clk_i, rst_ni)
-  `FFARNC(ptw_stage_q       , ptw_stage_d           , clear_i, S_STAGE, clk_i, rst_ni)
-  `FFARNC(is_instr_ptw_q    , is_instr_ptw_n        , clear_i, 1'b0   , clk_i, rst_ni)
-  `FFARNC(ptw_lvl_q         , ptw_lvl_n             , clear_i, LVL1   , clk_i, rst_ni)
-  `FFARNC(gptw_lvl_q        , gptw_lvl_n            , clear_i, LVL1   , clk_i, rst_ni)
-  `FFARNC(tag_valid_q       , tag_valid_n           , clear_i, 1'b0   , clk_i, rst_ni)
-  `FFARNC(tlb_update_asid_q , tlb_update_asid_n     , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(tlb_update_vmid_q , tlb_update_vmid_n     , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(vaddr_q           , vaddr_n               , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(gpaddr_q          , gpaddr_n              , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(ptw_pptr_q        , ptw_pptr_n            , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(gptw_pptr_q       , gptw_pptr_n           , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(global_mapping_q  , global_mapping_n      , clear_i, 1'b0   , clk_i, rst_ni)
-  `FFARNC(data_rdata_q      , req_port_i.data_rdata , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(gpte_q            , gpte_d                , clear_i, '0     , clk_i, rst_ni)
-  `FFARNC(data_rvalid_q     , req_port_i.data_rvalid, clear_i, 1'b0   , clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(ptw_stage_q, ptw_stage_d, clear_i, S_STAGE, clk_i, rst_ni)
+  `FFARNC(is_instr_ptw_q, is_instr_ptw_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(ptw_lvl_q, ptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
+  `FFARNC(gptw_lvl_q, gptw_lvl_n, clear_i, LVL1, clk_i, rst_ni)
+  `FFARNC(tag_valid_q, tag_valid_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(tlb_update_asid_q, tlb_update_asid_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(tlb_update_vmid_q, tlb_update_vmid_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(vaddr_q, vaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(gpaddr_q, gpaddr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(ptw_pptr_q, ptw_pptr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(gptw_pptr_q, gptw_pptr_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(global_mapping_q, global_mapping_n, clear_i, 1'b0, clk_i, rst_ni)
+  `FFARNC(data_rdata_q, req_port_i.data_rdata, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(gpte_q, gpte_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(data_rvalid_q, req_port_i.data_rvalid, clear_i, 1'b0, clk_i, rst_ni)
 
 endmodule
 /* verilator lint_on WIDTH */

--- a/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
@@ -16,6 +16,7 @@
 //              This module is an adaptation of the Sv39 TLB developed
 //              by Florian Zaruba and David Schaffenrath to the Sv39x4 standard.
 
+`include "common_cells/registers.svh"
 
 module cva6_tlb_sv39x4
   import ariane_pkg::*;
@@ -357,17 +358,10 @@ module cva6_tlb_sv39x4
   end
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      tags_q      <= '{default: 0};
-      content_q   <= '{default: 0};
-      plru_tree_q <= '{default: 0};
-    end else begin
-      tags_q      <= tags_n;
-      content_q   <= content_n;
-      plru_tree_q <= plru_tree_n;
-    end
-  end
+  `FFARNC(tags_q     , tags_n     , 1'b0, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(content_q  , content_n  , 1'b0, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(plru_tree_q, plru_tree_n, 1'b0, '{default: 0}, clk_i, rst_ni)
+
   //--------------
   // Sanity checks
   //--------------

--- a/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
@@ -359,8 +359,8 @@ module cva6_tlb_sv39x4
   end
 
   // sequential process
-  `FFARNC(tags_q     , tags_n     , clear_i, '{default: 0}, clk_i, rst_ni)
-  `FFARNC(content_q  , content_n  , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(tags_q, tags_n, clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(content_q, content_n, clear_i, '{default: 0}, clk_i, rst_ni)
   `FFARNC(plru_tree_q, plru_tree_n, clear_i, '{default: 0}, clk_i, rst_ni)
 
   //--------------

--- a/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
+++ b/core/mmu_sv39x4/cva6_tlb_sv39x4.sv
@@ -28,6 +28,7 @@ module cva6_tlb_sv39x4
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,
     input logic flush_i,  // Flush normal translations signal
     input logic flush_vvma_i,  // Flush vs stage signal
     input logic flush_gvma_i,  // Flush g stage signal
@@ -358,9 +359,9 @@ module cva6_tlb_sv39x4
   end
 
   // sequential process
-  `FFARNC(tags_q     , tags_n     , 1'b0, '{default: 0}, clk_i, rst_ni)
-  `FFARNC(content_q  , content_n  , 1'b0, '{default: 0}, clk_i, rst_ni)
-  `FFARNC(plru_tree_q, plru_tree_n, 1'b0, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(tags_q     , tags_n     , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(content_q  , content_n  , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(plru_tree_q, plru_tree_n, clear_i, '{default: 0}, clk_i, rst_ni)
 
   //--------------
   // Sanity checks

--- a/core/mult.sv
+++ b/core/mult.sv
@@ -1,4 +1,4 @@
-
+`include "common_cells/registers.svh"
 
 module mult
   import ariane_pkg::*;
@@ -9,6 +9,8 @@ module mult
     input  logic                             clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input  logic                             rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input  logic                             clear_i,
     // Flush - CONTROLLER
     input  logic                             flush_i,
     // FU data needed to execute instruction - ISSUE_STAGE
@@ -148,11 +150,6 @@ module mult
   // ---------------------
   // Registers
   // ---------------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      word_op_q <= '0;
-    end else begin
-      word_op_q <= word_op_d;
-    end
-  end
+  `FFARNC(word_op_q, word_op_d, clear_i, '0, clk_i, rst_ni)
+
 endmodule

--- a/core/mult.sv
+++ b/core/mult.sv
@@ -131,6 +131,7 @@ module mult
   ) i_div (
       .clk_i    (clk_i),
       .rst_ni   (rst_ni),
+      .clear_i  (clear_i),
       .id_i     (fu_data_i.trans_id),
       .op_a_i   (operand_a),
       .op_b_i   (operand_b),

--- a/core/mult.sv
+++ b/core/mult.sv
@@ -61,6 +61,7 @@ module mult
   ) i_multiplier (
       .clk_i,
       .rst_ni,
+      .clear_i,
       .trans_id_i     (fu_data_i.trans_id),
       .operation_i    (fu_data_i.operation),
       .operand_a_i    (fu_data_i.operand_a),

--- a/core/multiplier.sv
+++ b/core/multiplier.sv
@@ -14,6 +14,7 @@
 //              This unit relies on retiming features of the synthesizer
 //
 
+`include "common_cells/registers.svh"
 
 module multiplier
   import ariane_pkg::*;
@@ -24,6 +25,8 @@ module multiplier
     input  logic                             clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input  logic                             rst_ni,
+    // Synchronous clear active high
+    input  logic                             clear_i,
     // Multiplier transaction ID - Mult
     input  logic         [TRANS_ID_BITS-1:0] trans_id_i,
     // Multiplier instruction is valid - Mult
@@ -138,32 +141,14 @@ module multiplier
     endcase
   end
   if (CVA6Cfg.RVB) begin
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (~rst_ni) begin
-        clmul_q  <= '0;
-        clmulr_q <= '0;
-      end else begin
-        clmul_q  <= clmul_d;
-        clmulr_q <= clmulr_d;
-      end
-    end
+    `FFARNC(clmul_q, clmul_d, clear_i, '0, clk_i, rst_ni)
+    `FFARNC(clmulr_q, clmulr_d, clear_i, '0, clk_i, rst_ni)
   end
   // -----------------------
   // Output pipeline register
   // -----------------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      mult_valid_q  <= '0;
-      trans_id_q    <= '0;
-      operator_q    <= MUL;
-      mult_result_q <= '0;
-    end else begin
-      // Input silencing
-      trans_id_q    <= trans_id_i;
-      // Output Register
-      mult_valid_q  <= mult_valid;
-      operator_q    <= operator_d;
-      mult_result_q <= mult_result_d;
-    end
-  end
+  `FFARNC(mult_valid_q, mult_valid, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(trans_id_q, trans_id_i, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(operator_q, operator_d, clear_i, MUL, clk_i, rst_ni)
+  `FFARNC(mult_result_q, mult_result_d, clear_i, '0, clk_i, rst_ni)
 endmodule

--- a/core/perf_counters.sv
+++ b/core/perf_counters.sv
@@ -12,6 +12,7 @@
 // Date: 06.10.2017
 // Description: Performance counters
 
+`include "common_cells/registers.svh"
 
 module perf_counters
   import ariane_pkg::*;
@@ -21,6 +22,7 @@ module perf_counters
 ) (
     input logic clk_i,
     input logic rst_ni,
+    input logic clear_i,
     input logic debug_mode_i,  // debug mode
     // SRAM like interface
     input logic [11:0] addr_i,  // read/write address (up to 6 counters possible)
@@ -232,14 +234,7 @@ module perf_counters
   end
 
   //Registers
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      generic_counter_q <= '{default: 0};
-      mhpmevent_q       <= '{default: 0};
-    end else begin
-      generic_counter_q <= generic_counter_d;
-      mhpmevent_q       <= mhpmevent_d;
-    end
-  end
+  `FFARNC(generic_counter_q, generic_counter_d, clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(mhpmevent_q      , mhpmevent_d      , clear_i, '{default: 0}, clk_i, rst_ni)
 
 endmodule

--- a/core/perf_counters.sv
+++ b/core/perf_counters.sv
@@ -235,6 +235,6 @@ module perf_counters
 
   //Registers
   `FFARNC(generic_counter_q, generic_counter_d, clear_i, '{default: 0}, clk_i, rst_ni)
-  `FFARNC(mhpmevent_q      , mhpmevent_d      , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(mhpmevent_q, mhpmevent_d, clear_i, '{default: 0}, clk_i, rst_ni)
 
 endmodule

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -287,7 +287,7 @@ module scoreboard #(
     ) i_sel_gpr_clobbers (
         .clk_i  (clk_i),
         .rst_ni (rst_ni),
-        .flush_i(1'b0),
+        .flush_i(clear_i),
         .rr_i   ('0),
         .req_i  (gpr_clobber_vld[k]),
         .gnt_o  (),
@@ -306,7 +306,7 @@ module scoreboard #(
       ) i_sel_fpr_clobbers (
           .clk_i  (clk_i),
           .rst_ni (rst_ni),
-          .flush_i(1'b0),
+          .flush_i(clear_i),
           .rr_i   ('0),
           .req_i  (fpr_clobber_vld[k]),
           .gnt_o  (),
@@ -374,7 +374,7 @@ module scoreboard #(
   ) i_sel_rs1 (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .flush_i(1'b0),
+      .flush_i(clear_i),
       .rr_i   ('0),
       .req_i  (rs1_fwd_req),
       .gnt_o  (),
@@ -393,7 +393,7 @@ module scoreboard #(
   ) i_sel_rs2 (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .flush_i(1'b0),
+      .flush_i(clear_i),
       .rr_i   ('0),
       .req_i  (rs2_fwd_req),
       .gnt_o  (),
@@ -414,7 +414,7 @@ module scoreboard #(
   ) i_sel_rs3 (
       .clk_i  (clk_i),
       .rst_ni (rst_ni),
-      .flush_i(1'b0),
+      .flush_i(clear_i),
       .rr_i   ('0),
       .req_i  (rs3_fwd_req),
       .gnt_o  (),

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -12,6 +12,8 @@
 // Date: 08.04.2017
 // Description: Scoreboard - keeps track of all decoded, issued and committed instructions
 
+`include "common_cells/registers.svh"
+
 module scoreboard #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter type rs3_len_t = logic
@@ -20,6 +22,8 @@ module scoreboard #(
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // TO_BE_COMPLETED - TO_BE_COMPLETED
     output logic sb_full_o,
     // Flush only un-issued instructions - TO_BE_COMPLETED
@@ -429,19 +433,10 @@ module scoreboard #(
 
 
   // sequential process
-  always_ff @(posedge clk_i or negedge rst_ni) begin : regs
-    if (!rst_ni) begin
-      mem_q            <= '{default: sb_mem_t'(0)};
-      issue_cnt_q      <= '0;
-      commit_pointer_q <= '0;
-      issue_pointer_q  <= '0;
-    end else begin
-      issue_cnt_q      <= issue_cnt_n;
-      issue_pointer_q  <= issue_pointer_n;
-      mem_q            <= mem_n;
-      commit_pointer_q <= commit_pointer_n;
-    end
-  end
+  `FFARNC(issue_cnt_q     , issue_cnt_n     , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(issue_pointer_q , issue_pointer_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(mem_q           , mem_n           , clear_i, '{default: sb_mem_t'(0)}, clk_i, rst_ni)
+  `FFARNC(commit_pointer_q, commit_pointer_n, clear_i, '0, clk_i, rst_ni)
 
   //RVFI
   assign rvfi_issue_pointer_o  = issue_pointer_q;

--- a/core/scoreboard.sv
+++ b/core/scoreboard.sv
@@ -433,9 +433,9 @@ module scoreboard #(
 
 
   // sequential process
-  `FFARNC(issue_cnt_q     , issue_cnt_n     , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(issue_pointer_q , issue_pointer_n , clear_i, '0, clk_i, rst_ni)
-  `FFARNC(mem_q           , mem_n           , clear_i, '{default: sb_mem_t'(0)}, clk_i, rst_ni)
+  `FFARNC(issue_cnt_q, issue_cnt_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(issue_pointer_q, issue_pointer_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(mem_q, mem_n, clear_i, '{default: sb_mem_t'(0)}, clk_i, rst_ni)
   `FFARNC(commit_pointer_q, commit_pointer_n, clear_i, '0, clk_i, rst_ni)
 
   //RVFI

--- a/core/serdiv.sv
+++ b/core/serdiv.sv
@@ -247,17 +247,17 @@ module serdiv
   assign op_b_d = (b_reg_en) ? b_mux : op_b_q;
   assign res_d = (load_en) ? '0 : (res_reg_en) ? {res_q[$high(res_q)-1:0], ab_comp} : res_q;
 
-  `FFARNC(state_q        , state_d       , 1'b0, IDLE, clk_i, rst_ni)
-  `FFARNC(op_a_q         , op_a_d        , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(op_b_q         , op_b_d        , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(res_q          , res_d         , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(cnt_q          , cnt_d         , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(id_q           , id_d          , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(rem_sel_q      , rem_sel_d     , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(comp_inv_q     , comp_inv_d    , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(res_inv_q      , res_inv_d     , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(op_b_zero_q    , op_b_zero_d   , 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(op_b_neg_one_q , op_b_neg_one_d, 1'b0, '0  , clk_i, rst_ni)
-  `FFARNC(div_res_zero_q , div_res_zero_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(state_q, state_d, 1'b0, IDLE, clk_i, rst_ni)
+  `FFARNC(op_a_q, op_a_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(op_b_q, op_b_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(res_q, res_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(cnt_q, cnt_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(id_q, id_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(rem_sel_q, rem_sel_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(comp_inv_q, comp_inv_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(res_inv_q, res_inv_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(op_b_zero_q, op_b_zero_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(op_b_neg_one_q, op_b_neg_one_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(div_res_zero_q, div_res_zero_d, 1'b0, '0, clk_i, rst_ni)
 
 endmodule

--- a/core/serdiv.sv
+++ b/core/serdiv.sv
@@ -27,6 +27,8 @@ module serdiv
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Serdiv translation ID - Mult
     input logic [TRANS_ID_BITS-1:0] id_i,
     // A operand - Mult
@@ -247,17 +249,17 @@ module serdiv
   assign op_b_d = (b_reg_en) ? b_mux : op_b_q;
   assign res_d = (load_en) ? '0 : (res_reg_en) ? {res_q[$high(res_q)-1:0], ab_comp} : res_q;
 
-  `FFARNC(state_q, state_d, 1'b0, IDLE, clk_i, rst_ni)
-  `FFARNC(op_a_q, op_a_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(op_b_q, op_b_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(res_q, res_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(cnt_q, cnt_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(id_q, id_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(rem_sel_q, rem_sel_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(comp_inv_q, comp_inv_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(res_inv_q, res_inv_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(op_b_zero_q, op_b_zero_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(op_b_neg_one_q, op_b_neg_one_d, 1'b0, '0, clk_i, rst_ni)
-  `FFARNC(div_res_zero_q, div_res_zero_d, 1'b0, '0, clk_i, rst_ni)
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(op_a_q, op_a_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(op_b_q, op_b_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(res_q, res_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(cnt_q, cnt_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(id_q, id_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(rem_sel_q, rem_sel_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(comp_inv_q, comp_inv_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(res_inv_q, res_inv_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(op_b_zero_q, op_b_zero_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(op_b_neg_one_q, op_b_neg_one_d, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(div_res_zero_q, div_res_zero_d, clear_i, '0, clk_i, rst_ni)
 
 endmodule

--- a/core/serdiv.sv
+++ b/core/serdiv.sv
@@ -14,6 +14,7 @@
 // Date: 18.10.2018
 // Description: simple 64bit serial divider
 
+`include "common_cells/registers.svh"
 
 module serdiv
   import ariane_pkg::*;
@@ -246,34 +247,17 @@ module serdiv
   assign op_b_d = (b_reg_en) ? b_mux : op_b_q;
   assign res_d = (load_en) ? '0 : (res_reg_en) ? {res_q[$high(res_q)-1:0], ab_comp} : res_q;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
-    if (~rst_ni) begin
-      state_q        <= IDLE;
-      op_a_q         <= '0;
-      op_b_q         <= '0;
-      res_q          <= '0;
-      cnt_q          <= '0;
-      id_q           <= '0;
-      rem_sel_q      <= 1'b0;
-      comp_inv_q     <= 1'b0;
-      res_inv_q      <= 1'b0;
-      op_b_zero_q    <= 1'b0;
-      op_b_neg_one_q <= 1'b0;
-      div_res_zero_q <= 1'b0;
-    end else begin
-      state_q        <= state_d;
-      op_a_q         <= op_a_d;
-      op_b_q         <= op_b_d;
-      res_q          <= res_d;
-      cnt_q          <= cnt_d;
-      id_q           <= id_d;
-      rem_sel_q      <= rem_sel_d;
-      comp_inv_q     <= comp_inv_d;
-      res_inv_q      <= res_inv_d;
-      op_b_zero_q    <= op_b_zero_d;
-      op_b_neg_one_q <= op_b_neg_one_d;
-      div_res_zero_q <= div_res_zero_d;
-    end
-  end
+  `FFARNC(state_q        , state_d       , 1'b0, IDLE, clk_i, rst_ni)
+  `FFARNC(op_a_q         , op_a_d        , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(op_b_q         , op_b_d        , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(res_q          , res_d         , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(cnt_q          , cnt_d         , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(id_q           , id_d          , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(rem_sel_q      , rem_sel_d     , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(comp_inv_q     , comp_inv_d    , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(res_inv_q      , res_inv_d     , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(op_b_zero_q    , op_b_zero_d   , 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(op_b_neg_one_q , op_b_neg_one_d, 1'b0, '0  , clk_i, rst_ni)
+  `FFARNC(div_res_zero_q , div_res_zero_d, 1'b0, '0  , clk_i, rst_ni)
 
 endmodule

--- a/core/store_buffer.sv
+++ b/core/store_buffer.sv
@@ -13,6 +13,7 @@
 // Description: Store queue persists store requests and pushes them to memory
 //              if they are no longer speculative
 
+`include "common_cells/registers.svh"
 
 module store_buffer
   import ariane_pkg::*;
@@ -21,6 +22,7 @@ module store_buffer
 ) (
     input logic clk_i,  // Clock
     input logic rst_ni,  // Asynchronous reset active low
+    input logic clear_i,
     input logic flush_i,  // if we flush we need to pause the transactions on the memory
                           // otherwise we will run in a deadlock with the memory arbiter
     input logic stall_st_pending_i,  // Stall issuing non-speculative request
@@ -232,34 +234,15 @@ module store_buffer
 
 
   // registers
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_spec
-    if (~rst_ni) begin
-      speculative_queue_q         <= '{default: 0};
-      speculative_read_pointer_q  <= '0;
-      speculative_write_pointer_q <= '0;
-      speculative_status_cnt_q    <= '0;
-    end else begin
-      speculative_queue_q         <= speculative_queue_n;
-      speculative_read_pointer_q  <= speculative_read_pointer_n;
-      speculative_write_pointer_q <= speculative_write_pointer_n;
-      speculative_status_cnt_q    <= speculative_status_cnt_n;
-    end
-  end
+  `FFARNC(speculative_queue_q        , speculative_queue_n        , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(speculative_read_pointer_q , speculative_read_pointer_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(speculative_write_pointer_q, speculative_write_pointer_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(speculative_status_cnt_q   , speculative_status_cnt_n   , clear_i, '0, clk_i, rst_ni)
 
-  // registers
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_commit
-    if (~rst_ni) begin
-      commit_queue_q         <= '{default: 0};
-      commit_read_pointer_q  <= '0;
-      commit_write_pointer_q <= '0;
-      commit_status_cnt_q    <= '0;
-    end else begin
-      commit_queue_q         <= commit_queue_n;
-      commit_read_pointer_q  <= commit_read_pointer_n;
-      commit_write_pointer_q <= commit_write_pointer_n;
-      commit_status_cnt_q    <= commit_status_cnt_n;
-    end
-  end
+  `FFARNC(commit_queue_q        , commit_queue_n        , clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(commit_read_pointer_q , commit_read_pointer_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(commit_write_pointer_q, commit_write_pointer_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(commit_status_cnt_q   , commit_status_cnt_n   , clear_i, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/store_buffer.sv
+++ b/core/store_buffer.sv
@@ -234,15 +234,15 @@ module store_buffer
 
 
   // registers
-  `FFARNC(speculative_queue_q        , speculative_queue_n        , clear_i, '{default: 0}, clk_i, rst_ni)
-  `FFARNC(speculative_read_pointer_q , speculative_read_pointer_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(speculative_queue_q, speculative_queue_n, clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(speculative_read_pointer_q, speculative_read_pointer_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(speculative_write_pointer_q, speculative_write_pointer_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(speculative_status_cnt_q   , speculative_status_cnt_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(speculative_status_cnt_q, speculative_status_cnt_n, clear_i, '0, clk_i, rst_ni)
 
-  `FFARNC(commit_queue_q        , commit_queue_n        , clear_i, '{default: 0}, clk_i, rst_ni)
-  `FFARNC(commit_read_pointer_q , commit_read_pointer_n , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(commit_queue_q, commit_queue_n, clear_i, '{default: 0}, clk_i, rst_ni)
+  `FFARNC(commit_read_pointer_q, commit_read_pointer_n, clear_i, '0, clk_i, rst_ni)
   `FFARNC(commit_write_pointer_q, commit_write_pointer_n, clear_i, '0, clk_i, rst_ni)
-  `FFARNC(commit_status_cnt_q   , commit_status_cnt_n   , clear_i, '0, clk_i, rst_ni)
+  `FFARNC(commit_status_cnt_q, commit_status_cnt_n, clear_i, '0, clk_i, rst_ni)
 
   ///////////////////////////////////////////////////////
   // assertions

--- a/core/store_unit.sv
+++ b/core/store_unit.sv
@@ -12,6 +12,7 @@
 // Date: 22.05.2017
 // Description: Store Unit, takes care of all store requests and atomic memory operations (AMOs)
 
+`include "common_cells/registers.svh"
 
 module store_unit
   import ariane_pkg::*;
@@ -22,6 +23,8 @@ module store_unit
     input logic clk_i,
     // Asynchronous reset active low - SUBSYSTEM
     input logic rst_ni,
+    // Synchronous clear active high - SUBSYSTEM
+    input logic clear_i,
     // Flush - CONTROLLER
     input logic flush_i,
     // TO_BE_COMPLETED - TO_BE_COMPLETED
@@ -257,6 +260,7 @@ module store_unit
   ) store_buffer_i (
       .clk_i,
       .rst_ni,
+      .clear_i,
       .flush_i,
       .stall_st_pending_i,
       .no_st_pending_o,
@@ -308,22 +312,11 @@ module store_unit
   // ---------------
   // Registers
   // ---------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
-      state_q        <= IDLE;
-      st_be_q        <= '0;
-      st_data_q      <= '0;
-      st_data_size_q <= '0;
-      trans_id_q     <= '0;
-      amo_op_q       <= AMO_NONE;
-    end else begin
-      state_q        <= state_d;
-      st_be_q        <= st_be_n;
-      st_data_q      <= st_data_n;
-      trans_id_q     <= trans_id_n;
-      st_data_size_q <= st_data_size_n;
-      amo_op_q       <= amo_op_d;
-    end
-  end
+  `FFARNC(state_q, state_d, clear_i, IDLE, clk_i, rst_ni)
+  `FFARNC(st_be_q, st_be_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(st_data_q, st_data_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(trans_id_q, trans_id_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(st_data_size_q, st_data_size_n, clear_i, '0, clk_i, rst_ni)
+  `FFARNC(amo_op_q, amo_op_d, clear_i, AMO_NONE, clk_i, rst_ni)
 
 endmodule

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -61,6 +61,7 @@ module ariane import ariane_pkg::*; #(
   ) i_cva6 (
     .clk_i                ( clk_i                     ),
     .rst_ni               ( rst_ni                    ),
+    .clear_i              ( '0                        ),
     .boot_addr_i          ( boot_addr_i               ),
     .hart_id_i            ( hart_id_i                 ),
     .irq_i                ( irq_i                     ),

--- a/vendor/pulp-platform/common_cells/include/common_cells/registers.svh
+++ b/vendor/pulp-platform/common_cells/include/common_cells/registers.svh
@@ -208,6 +208,29 @@
     end                                                                    \
   end
 
+// Flip-Flop with asynchronous active-low reset and synchronous clear
+// __q: Q output of FF
+// __d: D input of FF
+// __clear: assign reset value into FF
+// __reset_value: value assigned upon reset
+// __clk: clock input
+// __arst_n: asynchronous reset, active-low
+`define FFARNC(__q, __d, __clear, __reset_value, __clk, __arst_n) \
+    `ifndef NO_SYNOPSYS_FF                                        \
+  /``* synopsys sync_set_reset `"__clear`" *``/                   \
+    `endif                                                        \
+  always_ff @(posedge (__clk) or negedge (__arst_n)) begin        \
+    if (!__arst_n) begin                                          \
+      __q <= (__reset_value);                                     \
+    end else begin                                                \
+      if (__clear) begin                                          \
+        __q <= (__reset_value);                                   \
+      end begin                                                   \
+        __q <= (__d);                                             \
+      end                                                         \
+    end                                                           \
+  end
+
 // Load-enable Flip-Flop without reset
 // __q: Q output of FF
 // __d: D input of FF


### PR DESCRIPTION
Synchronous clear is useful for applications where the core internal status must be flushed from the outside (for example, a redundant unit detects an error and needs to flush the core to bring its internals to a clear state), without compromising the regular asynchronous reset path.