### PR TITLE
Implement `Zicfiss` and `Zicfilp` extensions for Control-Flow Integrity

### DIFF
--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -203,6 +203,8 @@ module cva6
     CVA6Cfg.XFVec,
     CVA6Cfg.CvxifEn,
     CVA6Cfg.ZiCondExtEn,
+    CVA6Cfg.ZiCfiSSEn,
+    CVA6Cfg.ZiCfiLPEn,
     CVA6Cfg.RVSCLIC,
     // Extended
     bit'(RVF),

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -132,6 +132,7 @@ package ariane_pkg;
                                                    | riscv::SSTATUS_XS
                                                    | riscv::SSTATUS_SUM
                                                    | riscv::SSTATUS_MXR
+                                                   | riscv::SSTATUS_SPELP
                                                    | riscv::SSTATUS_UPIE
                                                    | riscv::SSTATUS_SPIE
                                                    | riscv::SSTATUS_UXL
@@ -139,6 +140,7 @@ package ariane_pkg;
 
   localparam logic [63:0] SMODE_STATUS_WRITE_MASK = riscv::SSTATUS_SIE
                                                     | riscv::SSTATUS_SPIE
+                                                    | riscv::SSTATUS_SPELP
                                                     | riscv::SSTATUS_SPP
                                                     | riscv::SSTATUS_FS
                                                     | riscv::SSTATUS_SUM
@@ -1067,7 +1069,7 @@ package ariane_pkg;
   function automatic logic is_trans_2M(input logic s_st_enbl, input logic g_st_enbl,
                                        input logic is_s_1G, input logic is_s_2M,
                                        input logic is_g_1G, input logic is_g_2M);
-    return  (s_st_enbl && g_st_enbl) ? 
+    return  (s_st_enbl && g_st_enbl) ?
                 ((is_s_2M && (is_g_1G || is_g_2M)) || (is_g_2M && (is_s_1G || is_s_2M))) :
                 ((is_s_2M && s_st_enbl) || (is_g_2M && g_st_enbl));
   endfunction : is_trans_2M

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -76,6 +76,10 @@ package config_pkg;
     bit                          CvxifEn;
     // Zicond RISC-V extension
     bit                          ZiCondExtEn;
+    // Control-Flow Integrity - Zicfiss extension
+    bit                          ZiCfiSSEn;
+    // Control-Flow Integrity - Zicfilp extension
+    bit                          ZiCfiLPEn;
     // CLIC extension
     bit                          RVSCLIC;
     // Single precision FP RISC-V extension
@@ -108,7 +112,7 @@ package config_pkg;
     bit                          RVU;
     // Address to jump when halt request
     logic [63:0]                 HaltAddress;
-    // Address to jump when exception 
+    // Address to jump when exception
     logic [63:0]                 ExceptionAddress;
     // Return address stack depth
     int unsigned                 RASDepth;

--- a/core/include/cv64a6_imafdcsclic_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcsclic_sv39_config_pkg.sv
@@ -27,6 +27,8 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigHExtEn = 1;
   localparam CVA6ConfigZiCondExtEn = 1;
+  localparam CVA6ConfigZiCfiSSEn = 1;
+  localparam CVA6ConfigZiCfiLPEn = 1;
   localparam CVA6ConfigSclicExtEn = 1;
 
   localparam CVA6ConfigAxiIdWidth = 4;
@@ -98,6 +100,8 @@ package cva6_config_pkg;
       XFVec: bit'(CVA6ConfigFVecEn),
       CvxifEn: bit'(CVA6ConfigCvxifEn),
       ZiCondExtEn: bit'(CVA6ConfigZiCondExtEn),
+      ZiCfiSSEn: bit'(CVA6ConfigZiCfiSSEn),
+      ZiCfiLPEn: bit'(CVA6ConfigZiCfiLPEn),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
       // Extended
       RVF:

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -83,9 +83,11 @@ package riscv;
 
   typedef struct packed {
     logic sd;  // signal dirty state - read-only
-    logic [62:34] wpri6;  // writes preserved reads ignored
+    logic [62:34] wpri7;  // writes preserved reads ignored
     xlen_e uxl;  // variable user mode xlen - hardwired to zero
-    logic [11:0] wpri5;  // writes preserved reads ignored
+    logic [7:0] wpri6;  // writes preserved reads ignored
+    logic spelp;  // hold previous ELP in S-mode
+    logic [2:0] wpri5;  // writes preserved reads ignored
     logic mxr;  // make executable readable
     logic sum;  // permit supervisor user memory access
     logic wpri4;  // writes preserved reads ignored
@@ -123,14 +125,17 @@ package riscv;
 
   typedef struct packed {
     logic sd;  // signal dirty state - read-only
-    logic [62:40] wpri4;  // writes preserved reads ignored
+    logic [62:42] wpri5;  // writes preserved reads ignored
+    logic mpelp;  // hold previous ELP in M-mode
+    logic wpri4;  // writes preserved reads ignored
     logic mpv;  // machine previous virtualization mode
     logic gva;  // variable set when trap writes to stval
     logic mbe;  // endianness memory accesses made from M-mode
     logic sbe;  // endianness memory accesses made from S-mode
     xlen_e sxl;  // variable supervisor mode xlen - hardwired to zero
     xlen_e uxl;  // variable user mode xlen - hardwired to zero
-    logic [8:0] wpri3;  // writes preserved reads ignored
+    logic [7:0] wpri3;  // writes preserved reads ignored
+    logic spelp;  // hold previous ELP in S-mode
     logic tsr;  // trap sret
     logic tw;  // time wait
     logic tvm;  // trap virtual memory
@@ -153,13 +158,26 @@ package riscv;
   } mstatus_rv_t;
 
   typedef struct packed {
+    logic [63:11] wpri1;  // writes preserved reads ignored
+    logic         mlpe;   // enable Zicfilp in M-mode
+    logic         sseed;  // not implemented - requires Zkr extension
+    logic         useed;  // not implemented - requires Zkr extension
+    logic [7:3]   wpri0;  // writes preserved reads ignored
+    logic         rlb;    // not implemented - requires Smepmp extension
+    logic         mmwp;   // not implemented - requires Smepmp extension
+    logic         mml;    // not implemented - requires Smepmp extension
+  } seccfg_rv_t;
+
+  typedef struct packed {
     logic        stce;   // not implemented - requires Sctc extension
     logic        pbmte;  // not implemented - requires Svpbmt extension
     logic [61:8] wpri1;  // writes preserved reads ignored
     logic        cbze;   // not implemented - requires Zicboz extension
     logic        cbcfe;  // not implemented - requires Zicbom extension
     logic [1:0]  cbie;   // not implemented - requires Zicbom extension
-    logic [2:0]  wpri0;  // writes preserved reads ignored
+    logic        sse;    // enable Zicfiss in less priviledged modes
+    logic        lpe;    // enable Zicfilp in less priviledged modes
+    logic        wpri0;  // writes preserved reads ignored
     logic        fiom;   // fence of I/O implies memory
   } envcfg_rv_t;
 
@@ -581,6 +599,8 @@ package riscv;
     CSR_MCYCLEH          = 12'hB80,
     CSR_MINSTRET         = 12'hB02,
     CSR_MINSTRETH        = 12'hB82,
+    CSR_MSECCFG          = 12'h747,
+    CSR_MSECCFGH         = 12'h757,
     //Performance Counters
     CSR_MHPM_COUNTER_3   = 12'hB03,
     CSR_MHPM_COUNTER_4   = 12'hB04,
@@ -658,6 +678,8 @@ package riscv;
     CSR_DPC              = 12'h7b1,
     CSR_DSCRATCH0        = 12'h7b2,  // optional
     CSR_DSCRATCH1        = 12'h7b3,  // optional
+    // Control-Flow Integrity - Zicfiss
+    CSR_SSP              = 12'h011,
     // Counters and Timers (User Mode - R/O Shadows)
     CSR_CYCLE            = 12'hC00,
     CSR_CYCLEH           = 12'hC80,
@@ -736,6 +758,7 @@ package riscv;
   localparam logic [63:0] SSTATUS_XS = 'h00018000;
   localparam logic [63:0] SSTATUS_SUM = 'h00040000;
   localparam logic [63:0] SSTATUS_MXR = 'h00080000;
+  localparam logic [63:0] SSTATUS_SPELP = 'h00800000;
   localparam logic [63:0] SSTATUS_UPIE = 'h00000010;
   localparam logic [63:0] SSTATUS_UXL = 64'h0000000300000000;
   localparam logic [63:0] SSTATUS_SD = {IS_XLEN64, 31'h00000000, ~IS_XLEN64, 31'h00000000};
@@ -767,21 +790,32 @@ package riscv;
   localparam logic [63:0] MSTATUS_MPRV = 'h00020000;
   localparam logic [63:0] MSTATUS_SUM = 'h00040000;
   localparam logic [63:0] MSTATUS_MXR = 'h00080000;
+  localparam logic [63:0] MSTATUS_SPELP = 'h00800000;
   localparam logic [63:0] MSTATUS_TVM = 'h00100000;
   localparam logic [63:0] MSTATUS_TW = 'h00200000;
   localparam logic [63:0] MSTATUS_TSR = 'h00400000;
   localparam logic [63:0] MSTATUS_UXL = {30'h0000000, IS_XLEN64, IS_XLEN64, 32'h00000000};
   localparam logic [63:0] MSTATUS_SXL = {28'h0000000, IS_XLEN64, IS_XLEN64, 34'h00000000};
+  localparam logic [63:0] MSTATUS_MPELP = 'h0000020000000000;
   localparam logic [63:0] MSTATUS_SD = {IS_XLEN64, 31'h00000000, ~IS_XLEN64, 31'h00000000};
 
-  localparam logic [63:0] MENVCFG_FIOM = 'h00000001;
-  localparam logic [63:0] MENVCFG_CBIE = 'h00000030;
-  localparam logic [63:0] MENVCFG_CBFE = 'h00000040;
-  localparam logic [63:0] MENVCFG_CBZE = 'h00000080;
-  localparam logic [63:0] MENVCFG_PBMTE = 64'h4000000000000000;
-  localparam logic [63:0] MENVCFG_STCE = 64'h8000000000000000;
+  // xENVCFG bit fields
+  localparam logic [63:0] ENVCFG_FIOM  = 64'h0000000000000001;
+  localparam logic [63:0] ENVCFG_LPE   = 64'h0000000000000004;
+  localparam logic [63:0] ENVCFG_SSE   = 64'h0000000000000008;
+  localparam logic [63:0] ENVCFG_CBIE  = 64'h0000000000000030;
+  localparam logic [63:0] ENVCFG_CBFE  = 64'h0000000000000040;
+  localparam logic [63:0] ENVCFG_CBZE  = 64'h0000000000000080;
+  localparam logic [63:0] ENVCFG_PBMTE = 64'h4000000000000000;
+  localparam logic [63:0] ENVCFG_STCE  = 64'h8000000000000000;
 
-
+  // xSECCFG bit fields
+  localparam logic [63:0] SECCFG_MML   = 64'h0000000000000001;
+  localparam logic [63:0] SECCFG_MMWP  = 64'h0000000000000002;
+  localparam logic [63:0] SECCFG_RLP   = 64'h0000000000000004;
+  localparam logic [63:0] SECCFG_USEED = 64'h0000000000000100;
+  localparam logic [63:0] SECCFG_SSEED = 64'h0000000000000200;
+  localparam logic [63:0] SECCFG_MLPE  = 64'h0000000000000400;
 
   typedef enum logic [2:0] {
     CSRRW  = 3'h1,
@@ -847,7 +881,8 @@ package riscv;
   // -----
   typedef struct packed {
     logic [31:28] xdebugver;
-    logic [27:18] zero2;
+    logic [27:19] zero2;
+    logic         pelp;
     logic         ebreakvs;
     logic         ebreakvu;
     logic         ebreakm;


### PR DESCRIPTION
Implement the `Zicfiss` and `Zicfilp` ISA extensions for Control-Flow Integrity.

`Zicfiss`
---
The Zicfiss extension introduces a shadow stack to enforce backward-edge control-flow integrity. A shadow stack is a second stack used to store a shadow copy of the return address in the link register if it needs to be spilled. The shadow stack is designed to provide integrity to control transfers performed using a return, where the return may be from a procedure invoked using an indirect call or a direct call, and this is referred to as backward-edge protection. The extension adds the following instructions:
- `SSPUSH x1`, `SSPUSH x5`
- `C.SSPUSH x1`
- `SSPOPCHK x1`, `SSPOPCHK x5`
- `C.SSPOPCHK x5`
- `SSRDP`
- `SSAMOSWAP.W`, `SSAMOSWAP.D`

`Zicfilp`
---
To enforce forward-edge control-flow integrity, the `Zicfilp` extension introduces a landing pad (`LPAD`) instruction. The `LPAD` instruction must be placed at the program locations that are valid targets of indirect jumps or calls. The `LPAD` instruction is encoded using the `AUIPC` major opcode with `rd` = `x0`.

Relevant links:
---
- [RISC-V Control-Flow Integrity Release v1.0-rc1](https://github.com/riscv/riscv-cfi/releases/tag/v1.0-rc1)