### PR TITLE
ci: Remove trigger `pull_request_target`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'pulp-platform/cva6' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Integrate into cheshire
-        uses: pulp-platform/pulp-actions/integrate@v2.2.0
+        uses: pulp-platform/pulp-actions/integrate@v2.3.0
         with:
           ip-name: cva6
           org: pulp-platform

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,13 +5,14 @@
 # Author: Nils Wistoff <nwistoff@iis.ee.ethz.ch>
 
 name: integration
-on: [ push, pull_request_target, workflow_dispatch ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   cheshire-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 200
-    if: github.repository == 'pulp-platform/cva6'
+    # Skip on forks due to missing secrets.
+    if: github.repository == 'pulp-platform/cva6' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Integrate into cheshire
         uses: pulp-platform/pulp-actions/integrate@v2.2.0

--- a/.github/workflows/verible.yml
+++ b/.github/workflows/verible.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Verible
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   format:
@@ -12,6 +12,8 @@ jobs:
       checks: write
       contents: read
       pull-requests: write
+    # Skip on forks due to missing secrets.
+    if: github.repository == 'pulp-platform/cva6' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - uses: actions/checkout@v3
         with:

--- a/ci/build-hyp-riscv-tests.sh
+++ b/ci/build-hyp-riscv-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-VERSION="920c1379cf6ca2374c6c5207dca425a933d8c7fd"
+VERSION="9ace7ffdb384ed84075dbe6219d9c0c9431f278b"
 
 cd $ROOT/tmp
 


### PR DESCRIPTION
Remove the `pull_request_target` trigger since it bypasses approvals and can therefore cause security issues.