### PR TITLE
axi_adapter/fence.t: Assert busy_o when any outstanding AW

### DIFF
--- a/core/cache_subsystem/axi_adapter.sv
+++ b/core/cache_subsystem/axi_adapter.sv
@@ -95,8 +95,8 @@ module axi_adapter #(
 
   assign any_outstanding_aw = outstanding_aw_cnt_q != '0;
 
-  // Busy if we're not idle
-  assign busy_o = state_q != IDLE;
+  // Busy if we're not idle or have outstanding writes
+  assign busy_o = (state_q != IDLE) || any_outstanding_aw;
 
   always_comb begin : axi_fsm
     // Default assignments


### PR DESCRIPTION
Assert `busy_o` whenever there is any outstanding AW transaction to prevent protocol violations (e.g., microreset during an inflight transaction).