### PR TITLE
Add vCLIC support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,6 @@ jobs:
           ip-name: cva6
           org: pulp-platform
           repo: cheshire
-          base-ref: cva6/pulp-v2.0.0-alpha.3
+          base-ref: 18825812740f492d4982fba97443c76fe8ab9cad
           token: ${{ secrets.CHESHIRE_TOKEN }}
           lifetime: 14

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -158,6 +158,8 @@ module csr_regfile
     // TO_BE_COMPLETED - CLIC_CTRL
     output logic [7:0] sintthresh_o,
     // TO_BE_COMPLETED - CLIC_CTRL
+    output logic [7:0] vsintthresh_o,
+    // TO_BE_COMPLETED - CLIC_CTRL
     output logic clic_irq_ready_o,
     // we are in single-step mode - COMMIT_STAGE
     output logic single_step_o,
@@ -286,10 +288,12 @@ module csr_regfile
   logic [CVA6Cfg.XLEN-1:0] htval_q, htval_d;
 
   logic [CVA6Cfg.XLEN-1:0] vstvec_q, vstvec_d;
+  logic [CVA6Cfg.XLEN-1:0] vstvt_q, vstvt_d;
   logic [CVA6Cfg.XLEN-1:0] vsscratch_q, vsscratch_d;
   logic [CVA6Cfg.XLEN-1:0] vsepc_q, vsepc_d;
   logic [CVA6Cfg.XLEN-1:0] vscause_q, vscause_d;
   logic [CVA6Cfg.XLEN-1:0] vstval_q, vstval_d;
+  riscv::intthresh_rv_t vsintthresh_q, vsintthresh_d;
 
   logic [CVA6Cfg.XLEN-1:0] dcache_q, dcache_d;
   logic [CVA6Cfg.XLEN-1:0] icache_q, icache_d;
@@ -366,6 +370,12 @@ module csr_regfile
     assign clic_irq_ready_o = 1'b0;
   end
 
+  if (CVA6Cfg.RVXHCLIC) begin : gen_clic_vsintthresh_signal
+    assign vsintthresh_o = vsintthresh_q.th;
+  end else begin : gen_dummy_clic_vsintthresh_signal
+    assign vsintthresh_o = '0;
+  end
+
   always_comb begin : csr_read_process
     // a read access exception can only occur if we attempt to read a CSR which does not exist
     read_access_exception = 1'b0;
@@ -434,14 +444,18 @@ module csr_regfile
         else read_access_exception = 1'b1;
         riscv::CSR_VSIE:
         if (CVA6Cfg.RVH)
-          csr_rdata = (mie_q & VS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0] & hideleg_q) >> 1;
+          csr_rdata = (CVA6Cfg.RVXHCLIC && clic_mode_o) ? '0 : ((mie_q & VS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0] & hideleg_q) >> 1);
         else read_access_exception = 1'b1;
         riscv::CSR_VSIP:
         if (CVA6Cfg.RVH)
-          csr_rdata = (mip_q & VS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0] & hideleg_q) >> 1;
+          csr_rdata = (CVA6Cfg.RVXHCLIC && clic_mode_o) ? '0 : ((mip_q & VS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0] & hideleg_q) >> 1);
         else read_access_exception = 1'b1;
         riscv::CSR_VSTVEC:
         if (CVA6Cfg.RVH) csr_rdata = vstvec_q;
+        else read_access_exception = 1'b1;
+        riscv::CSR_VSTVT:
+        if (CVA6Cfg.RVXHCLIC)
+          csr_rdata = clic_mode_o ? {vstvt_q, 8'b0} : '0;  // vstvt reads 0 in CLINT mode
         else read_access_exception = 1'b1;
         riscv::CSR_VSSCRATCH:
         if (CVA6Cfg.RVH) csr_rdata = vsscratch_q;
@@ -464,6 +478,10 @@ module csr_regfile
         end else begin
           read_access_exception = 1'b1;
         end
+        riscv::CSR_VSINTTHRESH:
+        if (CVA6Cfg.RVXHCLIC)
+          csr_rdata = clic_mode_o ? {{CVA6Cfg.XLEN - 8{1'b0}}, vsintthresh_q} : '0; // vsintthresh reads 0 in CLINT mode
+        else read_access_exception = 1'b1;
         // supervisor registers
         riscv::CSR_SSTATUS: begin
           if (CVA6Cfg.RVS) csr_rdata = mstatus_extended & SMODE_STATUS_READ_MASK[CVA6Cfg.XLEN-1:0];
@@ -556,13 +574,16 @@ module csr_regfile
         if (CVA6Cfg.RVH) csr_rdata = hideleg_q;
         else read_access_exception = 1'b1;
         riscv::CSR_HIE:
-        if (CVA6Cfg.RVH) csr_rdata = mie_q & HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0];
+        if (CVA6Cfg.RVH)
+          csr_rdata = (CVA6Cfg.RVXHCLIC && clic_mode_o) ? (mie_q & riscv::MIP_SGEIP) : (mie_q & HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0]);
         else read_access_exception = 1'b1;
         riscv::CSR_HIP:
-        if (CVA6Cfg.RVH) csr_rdata = mip_q & HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0];
+        if (CVA6Cfg.RVH)
+          csr_rdata = (CVA6Cfg.RVXHCLIC && clic_mode_o) ? '0 : (mip_q & HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0]);
         else read_access_exception = 1'b1;
         riscv::CSR_HVIP:
-        if (CVA6Cfg.RVH) csr_rdata = mip_q & VS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0];
+        if (CVA6Cfg.RVH)
+          csr_rdata = (CVA6Cfg.RVXHCLIC && clic_mode_o) ? '0 : (mip_q & VS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0]);
         else read_access_exception = 1'b1;
         riscv::CSR_HCOUNTEREN:
         if (CVA6Cfg.RVH) csr_rdata = hcounteren_q;
@@ -574,7 +595,7 @@ module csr_regfile
         if (CVA6Cfg.RVH) csr_rdata = htinst_q;
         else read_access_exception = 1'b1;
         riscv::CSR_HGEIE:
-        if (CVA6Cfg.RVH) csr_rdata = '0;
+        if (CVA6Cfg.RVH) csr_rdata = {hgeie_q[CVA6Cfg.XLEN-1:1], 1'b0};
         else read_access_exception = 1'b1;
         riscv::CSR_HGEIP:
         if (CVA6Cfg.RVH) csr_rdata = '0;
@@ -1103,6 +1124,11 @@ module csr_regfile
       en_ld_st_g_translation_d = en_ld_st_g_translation_q;
     end
 
+    if (CVA6Cfg.RVXHCLIC) begin
+      vstvt_d       = vstvt_q;
+      vsintthresh_d = vsintthresh_q;
+    end
+
     if (CVA6Cfg.RVS) begin
       sepc_d       = sepc_q;
       scause_d     = scause_q;
@@ -1218,13 +1244,19 @@ module csr_regfile
           end
         end
         riscv::CSR_VSIE:
-        if (CVA6Cfg.RVH) mie_d = (mie_q & ~hideleg_q) | ((csr_wdata << 1) & hideleg_q);
-        else update_access_exception = 1'b1;
+        if (CVA6Cfg.RVH) begin
+          // Writes are legal but ignored in CLIC mode
+          if (!(CVA6Cfg.RVXHCLIC && clic_mode_o))
+            mie_d = (mie_q & ~hideleg_q) | ((csr_wdata << 1) & hideleg_q);
+        end else update_access_exception = 1'b1;
         riscv::CSR_VSIP: begin
           if (CVA6Cfg.RVH) begin
-            // only the virtual supervisor software interrupt is write-able, iff delegated
-            mask  = CVA6Cfg.XLEN'(riscv::MIP_VSSIP) & hideleg_q;
-            mip_d = (mip_q & ~mask) | ((csr_wdata << 1) & mask);
+            // Writes are legal but ignored in CLIC mode
+            if (!(CVA6Cfg.RVXHCLIC && clic_mode_o)) begin
+              // only the virtual supervisor software interrupt is write-able, iff delegated
+              mask  = CVA6Cfg.XLEN'(riscv::MIP_VSSIP) & hideleg_q;
+              mip_d = (mip_q & ~mask) | ((csr_wdata << 1) & mask);
+            end
           end else begin
             update_access_exception = 1'b1;
           end
@@ -1235,6 +1267,12 @@ module csr_regfile
           end else begin
             update_access_exception = 1'b1;
           end
+        end
+        riscv::CSR_VSTVT: begin
+          if (CVA6Cfg.RVXHCLIC) begin
+            // Writes are legal but ignored in CLINT mode
+            if (clic_mode_o) vstvt_d = csr_wdata[CVA6Cfg.XLEN-1:8];
+          end else update_access_exception = 1'b1;
         end
         riscv::CSR_VSSCRATCH:
         if (CVA6Cfg.RVH) vsscratch_d = csr_wdata;
@@ -1268,6 +1306,12 @@ module csr_regfile
           end else begin
             update_access_exception = 1'b1;
           end
+        end
+        riscv::CSR_VSINTTHRESH: begin
+          if (CVA6Cfg.RVXHCLIC) begin
+            // Writes are legal but ignored in CLINT mode
+            if (clic_mode_o) vsintthresh_d.th = csr_wdata[7:0];
+          end else update_access_exception = 1'b1;
         end
         // sstatus is a subset of mstatus - mask it accordingly
         riscv::CSR_SSTATUS: begin
@@ -1422,7 +1466,8 @@ module csr_regfile
         end
         riscv::CSR_HIE: begin
           if (CVA6Cfg.RVH) begin
-            mask  = HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0];
+            // In CLIC mode only SGEIE bit is writable
+            mask  = (CVA6Cfg.RVXHCLIC && clic_mode_o) ? CVA6Cfg.XLEN'(riscv::MIP_SGEIP) : HS_DELEG_INTERRUPTS[CVA6Cfg.XLEN-1:0];
             mie_d = (mie_q & ~mask) | (csr_wdata & mask);
           end else begin
             update_access_exception = 1'b1;
@@ -1430,8 +1475,11 @@ module csr_regfile
         end
         riscv::CSR_HIP: begin
           if (CVA6Cfg.RVH) begin
-            mask  = CVA6Cfg.XLEN'(riscv::MIP_VSSIP);
-            mip_d = (mip_q & ~mask) | (csr_wdata & mask);
+            // Writes are legal but ignored in CLIC mode
+            if (!(CVA6Cfg.RVXHCLIC && clic_mode_o)) begin
+              mask  = CVA6Cfg.XLEN'(riscv::MIP_VSSIP);
+              mip_d = (mip_q & ~mask) | (csr_wdata & mask);
+            end
           end else begin
             update_access_exception = 1'b1;
           end
@@ -1465,12 +1513,9 @@ module csr_regfile
             update_access_exception = 1'b1;
           end
         end
-        //TODO Hyp: implement hgeie write
-        riscv::CSR_HGEIE: begin
-          if (!CVA6Cfg.RVH) begin
-            update_access_exception = 1'b1;
-          end
-        end
+        riscv::CSR_HGEIE:
+        if (CVA6Cfg.RVH) hgeie_d = {csr_wdata[CVA6Cfg.XLEN-1:1], 1'b0};
+        else update_access_exception = 1'b1;
         riscv::CSR_HGATP: begin
           if (CVA6Cfg.RVH) begin
             // intercept HGATP writes if in HS-Mode and TVM is enabled
@@ -2011,6 +2056,9 @@ module csr_regfile
               trap_to_v = v_q;
             end
           end
+        end else if (ex_i.cause[CVA6Cfg.XLEN-1] && clic_mode_o) begin
+          trap_to_priv_lvl = riscv::priv_lvl_t'(ex_i.cause[25:24]);
+          if (CVA6Cfg.RVXHCLIC) trap_to_v = ex_i.cause[26];
         end
       end
 
@@ -2023,7 +2071,12 @@ module csr_regfile
           // this can either be user or supervisor mode
           vsstatus_d.spp = priv_lvl_q[0];
           // set cause
-          vscause_d = ex_i.cause[CVA6Cfg.XLEN-1] ? {ex_i.cause[CVA6Cfg.XLEN-1:2], 2'b01} : ex_i.cause;
+          vscause_d = (~clic_mode_o && ex_i.cause[CVA6Cfg.XLEN-1]) ? {ex_i.cause[CVA6Cfg.XLEN-1:2], 2'b01} : ex_i.cause;
+          // update the current and previous interrupt level
+          if (CVA6Cfg.RVXHCLIC && clic_mode_o && ex_i.cause[CVA6Cfg.XLEN-1]) begin
+            mintstatus_d.vsil = ex_i.cause[23:16];
+            vscause_d[23:16]  = mintstatus_q.vsil;
+          end
           // set epc
           vsepc_d = {{CVA6Cfg.XLEN - CVA6Cfg.VLEN{pc_i[CVA6Cfg.VLEN-1]}}, pc_i};
           // set vstval
@@ -2344,6 +2397,9 @@ module csr_regfile
         vsstatus_d.spp  = 1'b0;
         // set spie to 1
         vsstatus_d.spie = 1'b1;
+        // restore vsintstatus
+        if (CVA6Cfg.RVXHCLIC && clic_mode_o && vscause_q[CVA6Cfg.XLEN-1])
+          mintstatus_d.vsil = vscause_q[23:16];
       end
     end
 
@@ -2423,6 +2479,8 @@ module csr_regfile
   end
   assign irq_ctrl_o.mideleg = (CVA6Cfg.RVS) ? mideleg_q : '0;
   assign irq_ctrl_o.hideleg = (CVA6Cfg.RVH) ? hideleg_q : '0;
+  assign irq_ctrl_o.hgeie = (CVA6Cfg.RVH) ? hgeie_q : '0;
+  assign irq_ctrl_o.vgein = (CVA6Cfg.RVH) ? hstatus_q.vgein : '0;
   assign irq_ctrl_o.global_enable = ~(CVA6Cfg.DebugEn & debug_mode_q)
       // interrupts are enabled during single step or we are not stepping
       // No need to check interrupts during single step if we don't support DEBUG mode
@@ -2592,7 +2650,11 @@ module csr_regfile
     // output user mode stvec
     if (CVA6Cfg.RVS && trap_to_priv_lvl == riscv::PRIV_LVL_S) begin
       if (CVA6Cfg.RVSCLIC && clic_mode_o && clic_irq_shv_i && ex_i.cause[CVA6Cfg.XLEN-1]) begin
-        trap_vector_base_o = {stvt_q[CVA6Cfg.VLEN-1:8], 8'b0};
+        if (CVA6Cfg.RVSCLIC && trap_to_v) begin
+          trap_vector_base_o = {vstvt_q[CVA6Cfg.VLEN-1:8], 8'b0};
+        end else begin
+          trap_vector_base_o = {stvt_q[CVA6Cfg.VLEN-1:8], 8'b0};
+        end
       end else if (CVA6Cfg.RVH && trap_to_v) begin
         trap_vector_base_o = {vstvec_q[CVA6Cfg.VLEN-1:2], 2'b0};
       end else begin
@@ -2818,6 +2880,10 @@ module csr_regfile
         vstval_q                 <= {CVA6Cfg.XLEN{1'b0}};
         vsatp_q                  <= {CVA6Cfg.XLEN{1'b0}};
         en_ld_st_g_translation_q <= 1'b0;
+        if (CVA6Cfg.RVXHCLIC) begin
+          vstvt_q       <= {CVA6Cfg.XLEN{1'b0}};
+          vsintthresh_q <= 8'b0;
+        end
       end
       // timer and counters
       cycle_q                <= 64'b0;
@@ -2911,6 +2977,10 @@ module csr_regfile
         vstval_q                 <= vstval_d;
         vsatp_q                  <= vsatp_d;
         en_ld_st_g_translation_q <= en_ld_st_g_translation_d;
+        if (CVA6Cfg.RVXHCLIC) begin
+          vstvt_q       <= vstvt_d;
+          vsintthresh_q <= vsintthresh_d;
+        end
       end
       // timer and counters
       cycle_q                <= cycle_d;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -147,6 +147,8 @@ module cva6
       logic [CVA6Cfg.XLEN-1:0] mip;
       logic [CVA6Cfg.XLEN-1:0] mideleg;
       logic [CVA6Cfg.XLEN-1:0] hideleg;
+      logic [CVA6Cfg.XLEN-1:0] hgeie;
+      logic [5:0]              vgein;
       logic                    sie;
       logic                    global_enable;
     },
@@ -331,6 +333,8 @@ module cva6
     input logic [$clog2(CVA6Cfg.CLICNumInterruptSrc)-1:0] clic_irq_id_i,  // interrupt source ID
     input logic [7:0] clic_irq_level_i,  // interrupt level is 8-bit from CLIC spec
     input riscv::priv_lvl_t clic_irq_priv_i,  // CLIC interrupt privilege level
+    input logic clic_irq_v_i,  // CLIC interrupt virtualization bit (only for vCLIC)
+    input logic [5:0] clic_irq_vsid_i,  // CLIC interrupt Virtual Supervisor ID (only for vCLIC)
     input logic clic_irq_shv_i,  // selective hardware vectoring bit
     output logic clic_irq_ready_o,  // core side interrupt hanshake (ready)
     input logic clic_kill_req_i,  // kill request
@@ -592,6 +596,7 @@ module cva6
   riscv::intstatus_rv_t mintstatus_csr;
   logic [7:0] mintthresh_csr;
   logic [7:0] sintthresh_csr;
+  logic [7:0] vsintthresh_csr;
   logic dcache_en_csr_nbdcache;
   logic csr_write_fflags_commit_cs;
   logic icache_en_csr;
@@ -1214,6 +1219,7 @@ module cva6
       .mintstatus_o            (mintstatus_csr),
       .mintthresh_o            (mintthresh_csr),
       .sintthresh_o            (sintthresh_csr),
+      .vsintthresh_o           (vsintthresh_csr),
       .clic_irq_req_i          (clic_irq_valid_i),
       .clic_irq_shv_i          (clic_irq_shv_i),
       .clic_irq_ready_o        (clic_irq_ready_o),
@@ -1695,9 +1701,11 @@ module cva6
         .rst_ni          (rst_ni),
         // from CSR file
         .priv_lvl_i      (priv_lvl),
+        .v_i             (v),
         .irq_ctrl_i      (irq_ctrl_csr_id),
         .mintthresh_i    (mintthresh_csr),
         .sintthresh_i    (sintthresh_csr),
+        .vsintthresh_i   (vsintthresh_csr),
         .mintstatus_i    (mintstatus_csr),
         // from/to CLIC
         .clic_irq_valid_i(clic_irq_valid_i),
@@ -1705,6 +1713,8 @@ module cva6
         .clic_irq_id_i   (clic_irq_id_i),
         .clic_irq_level_i(clic_irq_level_i),
         .clic_irq_priv_i (clic_irq_priv_i),
+        .clic_irq_v_i    (clic_irq_v_i),
+        .clic_irq_vsid_i (clic_irq_vsid_i),
         .clic_kill_req_i (clic_kill_req_i),
         .clic_kill_ack_o (clic_kill_ack_o),
         // to ID stage

--- a/core/cva6_clic_controller.sv
+++ b/core/cva6_clic_controller.sv
@@ -12,9 +12,11 @@ module cva6_clic_controller #(
     input logic rst_ni,
     // from CSR file
     input riscv::priv_lvl_t priv_lvl_i,  // current privilege level
+    input logic v_i,  // virtualization mode bit
     input irq_ctrl_t irq_ctrl_i,
     input logic [7:0] mintthresh_i,  // M-mode interrupt threshold
     input logic [7:0] sintthresh_i,  // S-mode interrupt threshold
+    input logic [7:0] vsintthresh_i,  // VS-mode interrupt threshold
     input riscv::intstatus_rv_t mintstatus_i,  // interrupt status
     // from/to CLIC
     input logic clic_irq_valid_i,  // interrupt is valid
@@ -22,6 +24,8 @@ module cva6_clic_controller #(
     input logic [$clog2(CVA6Cfg.CLICNumInterruptSrc)-1:0] clic_irq_id_i,  // interrupt ID
     input logic [7:0] clic_irq_level_i,  // interrupt level
     input riscv::priv_lvl_t clic_irq_priv_i,  // interrupt privilege level
+    input logic clic_irq_v_i,  // interrupt virtualization bit
+    input logic [5:0] clic_irq_vsid_i,  // interrupt Virtual Supervisor ID
     input logic clic_kill_req_i,  // kill request
     output logic clic_kill_ack_o,  // kill acknowledge
     // to ID stage
@@ -35,14 +39,22 @@ module cva6_clic_controller #(
   // irq threshold and global interrupt are enabled (otherwise it won't fire).
   // The effective interrupt threshold is the maximum of mintstatus.mil and
   // mintthresh, because interrupts with higher level have priority.
-  logic [7:0] max_mthresh, max_sthresh;
+  logic [7:0] max_mthresh, max_sthresh, max_vsthresh;
+
+  logic clic_irq_v;  // Interrupt targets virtualization mode
+
+  logic sgeie;  // Guest external interrupts at hypervisor level enable (HIE register)
 
   assign max_mthresh = mintthresh_i > mintstatus_i.mil ? mintthresh_i : mintstatus_i.mil;
   assign max_sthresh = sintthresh_i > mintstatus_i.sil ? sintthresh_i : mintstatus_i.sil;
+  assign max_vsthresh = vsintthresh_i > mintstatus_i.vsil ? vsintthresh_i : mintstatus_i.vsil;
+
+  assign sgeie = (CVA6Cfg.RVH) ? irq_ctrl_i.mie[riscv::IRQ_HS_EXT] : 1'b0;
 
   // Determine if CLIC interrupt shall be accepted
   always_comb begin : clic_irq_accept
     clic_irq_req_o = 1'b0;
+    clic_irq_v = 1'b0;
     unique case (priv_lvl_i)
       riscv::PRIV_LVL_M: begin
         // Take M-mode interrupts with higher level
@@ -56,12 +68,56 @@ module cva6_clic_controller #(
           clic_irq_req_o = clic_irq_valid_i;
           // Take S-mode interrupts with higher level
         end else if (clic_irq_priv_i == riscv::PRIV_LVL_S) begin
-          clic_irq_req_o = (clic_irq_level_i > max_sthresh) && (clic_irq_valid_i) && irq_ctrl_i.sie;
+          if (CVA6Cfg.RVH && v_i) begin  // Hart currently in VS-mode
+            if (CVA6Cfg.RVXHCLIC && clic_irq_v_i) begin  // Virtual supervisor interrrupt
+              if (clic_irq_vsid_i == irq_ctrl_i.vgein) begin // VS-mode interrupt is for currently running VS
+                clic_irq_req_o = (clic_irq_level_i > max_vsthresh) && (clic_irq_valid_i) && irq_ctrl_i.sie;
+                clic_irq_v = 1'b1;
+              end else begin  // Received interrupt is delegated to a differet VS
+                // Trap to HS-mode iff HIE.sgeie is set and HGEIE[vsid] is set
+                clic_irq_req_o = (clic_irq_valid_i) && sgeie && irq_ctrl_i.hgeie[clic_irq_vsid_i];
+              end
+            end else begin  // Hypervisor interrupt
+              clic_irq_req_o = (clic_irq_level_i > max_sthresh) && (clic_irq_valid_i); // HS-mode sie is implicitly enabled in VS-mode
+            end
+          end else begin  // Hart currently in (H)S-mode
+            if (CVA6Cfg.RVXHCLIC && clic_irq_v_i) begin  // Virtual supervisor interrrupt
+              // The current custom vCLIC implementation does not provide a way to the hypervisor to set interrupt levels
+              // to interrupts delegated to VS-mode. The incoming interrupt level is therefore ignored if the hart is running
+              // in HS-mode and a VS-mode interrupt is taken iff both HIE.sgeie and HGEIE[vsid] bits are set (and interrupts
+              // are globally enabled at supervisor level (i.e. MSTATUS.sie bit is set)
+              clic_irq_req_o = (clic_irq_valid_i) && sgeie && irq_ctrl_i.hgeie[clic_irq_vsid_i] && irq_ctrl_i.sie;
+            end else begin  // (Host) Supervisor interrupt
+              clic_irq_req_o = (clic_irq_level_i > max_sthresh) && (clic_irq_valid_i) && irq_ctrl_i.sie;
+            end
+          end
         end
       end
       riscv::PRIV_LVL_U: begin
-        // Take all M-mode and S-mode interrupts
-        clic_irq_req_o = clic_irq_valid_i;
+        // Take all M-mode interrupts
+        if (clic_irq_priv_i == riscv::PRIV_LVL_M) begin
+          clic_irq_req_o = clic_irq_valid_i;
+        end else if (clic_irq_priv_i == riscv::PRIV_LVL_S) begin
+          if (CVA6Cfg.RVH && v_i) begin  // Hart currently in VU-mode
+            if (CVA6Cfg.RVXHCLIC && clic_irq_v_i) begin  // Virtual supervisor interrrupt
+              if (clic_irq_vsid_i == irq_ctrl_i.vgein) begin // VS-mode interrupt is for currently running VS
+                clic_irq_req_o = clic_irq_valid_i;
+                clic_irq_v = 1'b1;
+              end else begin  // Received interrupt is delegated to a differet VS
+                // Trap to HS-mode iff HIE.sgeie is set and HGEIE[vsid] is set
+                clic_irq_req_o = (clic_irq_valid_i) && sgeie && irq_ctrl_i.hgeie[clic_irq_vsid_i];
+              end
+            end else begin  // Hypervisor interrupt
+              clic_irq_req_o = clic_irq_valid_i;  // MSTATUS.sie is implicitly enabled in VU-mode
+            end
+          end else begin  // Hart currently in U-mode
+            if (CVA6Cfg.RVXHCLIC && clic_irq_v_i) begin  // Virtual supervisor interrrupt
+              clic_irq_req_o = (clic_irq_valid_i) && sgeie && irq_ctrl_i.hgeie[clic_irq_vsid_i]; // MSTATUS.sie is implicitly enabled in U-mode
+            end else begin  // (Host) Supervisor interrupt
+              clic_irq_req_o = clic_irq_valid_i;  // HS-mode sie is implicitly enabled in U-mode
+            end
+          end
+        end
       end
       default: ;
     endcase
@@ -73,7 +129,9 @@ module cva6_clic_controller #(
   // Pack interrupt cause to be inserted into the pipeline
   assign clic_irq_cause_o = {
     1'b1,  // This is an irq
-    {CVA6Cfg.XLEN - 25{1'b0}},  // XLEN-2...24
+    {riscv::XLEN - 28{1'b0}},  // XLEN-2...27
+    clic_irq_v,  // 26: interrupt target virtualization mode
+    clic_irq_priv_i,  // 25..24: interrupt target privilege level
     clic_irq_level_i,  // to mintstatus.mil
     {16 - $clog2(CVA6Cfg.CLICNumInterruptSrc) {1'b0}},  // 15...IDWidth
     clic_irq_id_i

--- a/core/include/ariane_pkg.sv
+++ b/core/include/ariane_pkg.sv
@@ -138,13 +138,14 @@ package ariane_pkg;
                                                     | riscv::HSTATUS_SPV
                                                     | riscv::HSTATUS_SPVP
                                                     | riscv::HSTATUS_HU
+                                                    | riscv::HSTATUS_VGEIN
                                                     | riscv::HSTATUS_VTVM
                                                     | riscv::HSTATUS_VTW
                                                     | riscv::HSTATUS_VTSR;
 
   // hypervisor delegable interrupts
   function automatic logic [31:0] hs_deleg_interrupts(config_pkg::cva6_cfg_t Cfg);
-    return riscv::MIP_VSSIP | riscv::MIP_VSTIP | riscv::MIP_VSEIP;
+    return riscv::MIP_VSSIP | riscv::MIP_VSTIP | riscv::MIP_VSEIP | riscv::MIP_SGEIP;
   endfunction
 
   // virtual supervisor delegable interrupts

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -76,6 +76,7 @@ package build_config_pkg;
     cfg.RVZCMT = CVA6Cfg.RVZCMT;
     cfg.RVZCMP = CVA6Cfg.RVZCMP;
     cfg.RVSCLIC = CVA6Cfg.RVSCLIC;
+    cfg.RVXHCLIC = CVA6Cfg.RVXHCLIC;
     cfg.XFVec = CVA6Cfg.XFVec;
     cfg.CvxifEn = CVA6Cfg.CvxifEn;
     cfg.CoproType = CVA6Cfg.CoproType;

--- a/core/include/config_pkg.sv
+++ b/core/include/config_pkg.sv
@@ -84,6 +84,8 @@ package config_pkg;
     bit                          RVZCMT;
     // CLIC extension
     bit                          RVSCLIC;
+    // CLIC virtualization extension (vCLIC)
+    bit                          RVXHCLIC;
     // Zicond RISC-V extension
     bit                          RVZiCond;
     // Zicntr RISC-V extension
@@ -287,6 +289,7 @@ package config_pkg;
     bit          RVZCMP;
     bit          RVZCMT;
     bit          RVSCLIC;
+    bit          RVXHCLIC;
     bit          XFVec;
     bit          CvxifEn;
     copro_type_t CoproType;
@@ -422,6 +425,7 @@ package config_pkg;
     assert (Cfg.NrExecuteRegionRules <= NrMaxRules);
     assert (Cfg.NrCachedRegionRules <= NrMaxRules);
     assert (Cfg.NrPMPEntries <= 64);
+    assert (!(Cfg.RVXHCLIC && (!Cfg.RVH || !Cfg.RVSCLIC)));
     assert (!(Cfg.SuperscalarEn && Cfg.RVF));
     assert (Cfg.FETCH_WIDTH == 32 || Cfg.FETCH_WIDTH == 64)
     else $fatal(1, "[frontend] fetch width != not supported");

--- a/core/include/cv32a60x_config_pkg.sv
+++ b/core/include/cv32a60x_config_pkg.sv
@@ -14,6 +14,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigRvfiTrace = 1;
 
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;  // axi_pkg.sv
   localparam CVA6ConfigAxiAddrWidth = 64;  // axi_pkg.sv
@@ -53,6 +54,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_EXAMPLE,
       RVZiCond: bit'(0),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(0),
       RVZihpm: bit'(0),
       NrScoreboardEntries: unsigned'(4),

--- a/core/include/cv32a65x_config_pkg.sv
+++ b/core/include/cv32a65x_config_pkg.sv
@@ -14,6 +14,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigRvfiTrace = 1;
 
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;  // axi_pkg.sv
   localparam CVA6ConfigAxiAddrWidth = 64;  // axi_pkg.sv
@@ -54,6 +55,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_EXAMPLE,
       RVZiCond: bit'(0),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(0),
       RVZihpm: bit'(0),
       NrScoreboardEntries: unsigned'(8),

--- a/core/include/cv32a6_embedded_config_pkg_deprecated.sv
+++ b/core/include/cv32a6_embedded_config_pkg_deprecated.sv
@@ -29,6 +29,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -109,6 +110,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
+++ b/core/include/cv32a6_ima_sv32_fpga_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -107,6 +108,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv32a6_imac_sv0_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv0_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -107,6 +108,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv32a6_imac_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imac_sv32_config_pkg.sv
@@ -29,6 +29,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -106,6 +107,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv32a6_imafc_sv32_config_pkg.sv
+++ b/core/include/cv32a6_imafc_sv32_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -107,6 +108,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
+++ b/core/include/cv64a6_imadfcv_sv39_polara_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 1;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdc_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_config_pkg.sv
@@ -37,6 +37,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -117,6 +118,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_hpdcache_wb_config_pkg.sv
@@ -37,6 +37,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -117,6 +118,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_openpiton_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdc_sv39_wb_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdch_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdch_sv39_wb_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigHExtEn = 1;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdchsclic_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdchsclic_sv39_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 1;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdchsclic_sv39_hpdcache_config_pkg.sv
+++ b/core/include/cv64a6_imafdchsclic_sv39_hpdcache_config_pkg.sv
@@ -37,6 +37,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 1;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -117,6 +118,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdchsclic_sv39_wb_config_pkg.sv
+++ b/core/include/cv64a6_imafdchsclic_sv39_wb_config_pkg.sv
@@ -30,6 +30,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 0;
   localparam CVA6ConfigRVZiCond = 1;
   localparam CVA6ConfigSclicExtEn = 1;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -110,6 +111,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
+++ b/core/include/cv64a6_imafdcv_sv39_config_pkg.sv
@@ -32,6 +32,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigVExtEn = 1;
   localparam CVA6ConfigRVZiCond = 0;
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;
   localparam CVA6ConfigAxiAddrWidth = 64;
@@ -112,6 +113,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(CVA6ConfigRVZiCond),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/cv64a6_mmu_config_pkg.sv
+++ b/core/include/cv64a6_mmu_config_pkg.sv
@@ -15,6 +15,7 @@ package cva6_config_pkg;
   localparam CVA6ConfigRvfiTrace = 1;
 
   localparam CVA6ConfigSclicExtEn = 0;
+  localparam CVA6ConfigXhclicExtEn = 0;
 
   localparam CVA6ConfigAxiIdWidth = 4;  // axi_pkg.sv
   localparam CVA6ConfigAxiAddrWidth = 64;  // axi_pkg.sv
@@ -60,6 +61,7 @@ package cva6_config_pkg;
       CoproType: config_pkg::COPRO_NONE,
       RVZiCond: bit'(0),
       RVSCLIC: bit'(CVA6ConfigSclicExtEn),
+      RVXHCLIC: bit'(CVA6ConfigXhclicExtEn),
       RVZicntr: bit'(1),
       RVZihpm: bit'(1),
       NrScoreboardEntries: unsigned'(CVA6ConfigNrScoreboardEntries),

--- a/core/include/riscv_pkg.sv
+++ b/core/include/riscv_pkg.sv
@@ -133,7 +133,7 @@ package riscv;
 
   typedef struct packed {
     logic [7:0] mil;
-    logic [7:0] wpri;
+    logic [7:0] vsil;
     logic [7:0] sil;
     logic [7:0] uil;
   } intstatus_rv_t;
@@ -409,11 +409,13 @@ package riscv;
     CSR_VSSTATUS         = 12'h200,
     CSR_VSIE             = 12'h204,
     CSR_VSTVEC           = 12'h205,
+    CSR_VSTVT            = 12'h207,
     CSR_VSSCRATCH        = 12'h240,
     CSR_VSEPC            = 12'h241,
     CSR_VSCAUSE          = 12'h242,
     CSR_VSTVAL           = 12'h243,
     CSR_VSIP             = 12'h244,
+    CSR_VSINTTHRESH      = 12'h247,
     CSR_VSATP            = 12'h280,
     // Supervisor Mode CSRs
     CSR_SSTATUS          = 12'h100,


### PR DESCRIPTION
This PR adds support for the custom _vCLIC_ extension. 

It is a replacement of the previous PR, with only changes strictly relevant to _vCLIC_. It also makes the extension parametrized on an additional `RVVCLIC` parameter, which depends on `RVH` and `RVSCLIC` parameters and can be used to enable / disable the virtualization extension support. 

The main changes are:

1. CSRs: Implemented `HGEIE` write logic and functionality. Added vCLIC-specific `VSTVT` and `VSINTTHRESH` registers. 
2. CLIC interface: Adapted core interface and CLIC controller logic to vCLIC.