### PR TITLE
Add OS support to Ara

### DIFF
--- a/common/local/util/instr_tracer.sv
+++ b/common/local/util/instr_tracer.sv
@@ -121,6 +121,8 @@ module instr_tracer (
             address_mapping = load_mapping.pop_front();
           else if (tracer_if.pck.commit_instr[i].fu == ariane_pkg::STORE)
             address_mapping = store_mapping.pop_front();
+          else if (tracer_if.pck.commit_instr[i].fu == ariane_pkg::ACCEL)
+            address_mapping = '0; // Not yet implemented
 
           if (tracer_if.pck.commit_instr[i].fu == ariane_pkg::CTRL_FLOW)
             bp_instruction = bp.pop_front();

--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -257,7 +257,7 @@ module acc_dispatcher
       };
       // Wait until the instruction is no longer speculative.
       acc_req_valid      = insn_ready_q[acc_insn_queue_o.trans_id] ||
-                           (acc_commit && insn_pending_q[acc_commit_trans_id]);
+                           (acc_commit && insn_pending_q[acc_commit_trans_id] && !flush_unissued_instr_i);
       acc_insn_queue_pop = acc_req_valid && acc_req_ready;
     end
   end

--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -262,19 +262,13 @@ module acc_dispatcher
   logic acc_st_disp;
 
   // Unpack the accelerator response
-  assign acc_trans_id_o = acc_resp_i.trans_id;
-  assign acc_result_o = acc_resp_i.result;
-  assign acc_valid_o = acc_resp_i.resp_valid;
-  assign acc_exception_o = '{
-          cause: riscv::ILLEGAL_INSTR,
-          tval : '0,
-          tval2 : '0,
-          tinst : '0,
-          gva : '0,
-          valid: acc_resp_i.error
-      };
+  assign acc_trans_id_o     = acc_resp_i.trans_id;
+  assign acc_result_o       = acc_resp_i.result;
+  assign acc_valid_o        = acc_resp_i.resp_valid;
+  assign acc_exception_o    = acc_resp_i.exception;
   assign acc_fflags_valid_o = acc_resp_i.fflags_valid;
-  assign acc_fflags_o = acc_resp_i.fflags;
+  assign acc_fflags_o       = acc_resp_i.fflags;
+
   // Always ready to receive responses
   assign acc_req_o.resp_ready = 1'b1;
 

--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -199,13 +199,11 @@ module acc_dispatcher
   logic                      acc_req_ready;
 
   acc_pkg::accelerator_req_t acc_req_int;
-  fall_through_register #(
+  spill_register #(
       .T(acc_pkg::accelerator_req_t)
   ) i_accelerator_req_register (
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
-      .clr_i     (1'b0),
-      .testmode_i(1'b0),
       .data_i    (acc_req),
       .valid_i   (acc_req_valid),
       .ready_o   (acc_req_ready),

--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -18,8 +18,8 @@ module acc_dispatcher
   import riscv::*;
 #(
     parameter config_pkg::cva6_cfg_t CVA6Cfg    = config_pkg::cva6_cfg_empty,
-    parameter type                   acc_req_t  = acc_pkg::accelerator_req_t,
-    parameter type                   acc_resp_t = acc_pkg::accelerator_resp_t,
+    parameter type                   acc_req_t  = acc_pkg::cva6_to_acc_t,
+    parameter type                   acc_resp_t = acc_pkg::acc_to_cva6_t,
     parameter type                   acc_cfg_t  = logic,
     parameter acc_cfg_t              AccCfg     = '0
 ) (
@@ -187,7 +187,7 @@ module acc_dispatcher
     end
 
     // An accelerator instruction was issued.
-    if (acc_req_o.req_valid) insn_ready_d[acc_req_o.trans_id] = 1'b0;
+    if (acc_req_o.acc_req.req_valid) insn_ready_d[acc_req_o.acc_req.trans_id] = 1'b0;
   end : p_non_speculative_ff
 
   /*************************
@@ -210,18 +210,18 @@ module acc_dispatcher
       .valid_i   (acc_req_valid),
       .ready_o   (acc_req_ready),
       .data_o    (acc_req_int),
-      .valid_o   (acc_req_o.req_valid),
-      .ready_i   (acc_resp_i.req_ready)
+      .valid_o   (acc_req_o.acc_req.req_valid),
+      .ready_i   (acc_resp_i.acc_resp.req_ready)
   );
 
-  assign acc_req_o.insn          = acc_req_int.insn;
-  assign acc_req_o.rs1           = acc_req_int.rs1;
-  assign acc_req_o.rs2           = acc_req_int.rs2;
-  assign acc_req_o.frm           = acc_req_int.frm;
-  assign acc_req_o.trans_id      = acc_req_int.trans_id;
-  assign acc_req_o.store_pending = !acc_no_st_pending_i && acc_cons_en_i;
-  assign acc_req_o.acc_cons_en   = acc_cons_en_i;
-  assign acc_req_o.inval_ready   = inval_ready_i;
+  assign acc_req_o.acc_req.insn          = acc_req_int.insn;
+  assign acc_req_o.acc_req.rs1           = acc_req_int.rs1;
+  assign acc_req_o.acc_req.rs2           = acc_req_int.rs2;
+  assign acc_req_o.acc_req.frm           = acc_req_int.frm;
+  assign acc_req_o.acc_req.trans_id      = acc_req_int.trans_id;
+  assign acc_req_o.acc_req.store_pending = !acc_no_st_pending_i && acc_cons_en_i;
+  assign acc_req_o.acc_req.acc_cons_en   = acc_cons_en_i;
+  assign acc_req_o.acc_req.inval_ready   = inval_ready_i;
 
   // MMU interface
   assign acc_req_o.acc_mmu_resp = acc_mmu_resp_i;
@@ -270,26 +270,26 @@ module acc_dispatcher
   logic acc_st_disp;
 
   // Unpack the accelerator response
-  assign acc_trans_id_o     = acc_resp_i.trans_id;
-  assign acc_result_o       = acc_resp_i.result;
-  assign acc_valid_o        = acc_resp_i.resp_valid;
-  assign acc_exception_o    = acc_resp_i.exception;
-  assign acc_fflags_valid_o = acc_resp_i.fflags_valid;
-  assign acc_fflags_o       = acc_resp_i.fflags;
+  assign acc_trans_id_o     = acc_resp_i.acc_resp.trans_id;
+  assign acc_result_o       = acc_resp_i.acc_resp.result;
+  assign acc_valid_o        = acc_resp_i.acc_resp.resp_valid;
+  assign acc_exception_o    = acc_resp_i.acc_resp.exception;
+  assign acc_fflags_valid_o = acc_resp_i.acc_resp.fflags_valid;
+  assign acc_fflags_o       = acc_resp_i.acc_resp.fflags;
 
   // MMU interface
   assign acc_mmu_req_o = acc_resp_i.acc_mmu_req;
 
   // Always ready to receive responses
-  assign acc_req_o.resp_ready = 1'b1;
+  assign acc_req_o.acc_req.resp_ready = 1'b1;
 
   // Signal dispatched load/store to issue stage
   assign acc_ld_disp = acc_req_valid && (acc_insn_queue_o.operation == ACCEL_OP_LOAD);
   assign acc_st_disp = acc_req_valid && (acc_insn_queue_o.operation == ACCEL_OP_STORE);
 
   // Cache invalidation
-  assign inval_valid_o = acc_resp_i.inval_valid;
-  assign inval_addr_o = acc_resp_i.inval_addr;
+  assign inval_valid_o = acc_resp_i.acc_resp.inval_valid;
+  assign inval_addr_o = acc_resp_i.acc_resp.inval_addr;
 
   /**************************
    *  Accelerator commit    *
@@ -327,7 +327,7 @@ module acc_dispatcher
   `FF(wait_acc_store_q, wait_acc_store_d, '0)
 
   // Set on store barrier. Clear when no store is pending.
-  assign wait_acc_store_d = (wait_acc_store_q | commit_st_barrier_i) & acc_resp_i.store_pending;
+  assign wait_acc_store_d = (wait_acc_store_q | commit_st_barrier_i) & acc_resp_i.acc_resp.store_pending;
   assign ctrl_halt_o      = wait_acc_store_q;
 
   /**************************
@@ -366,9 +366,9 @@ module acc_dispatcher
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .clear_i   (1'b0),
-      .en_i      (acc_ld_disp ^ acc_resp_i.load_complete),
+      .en_i      (acc_ld_disp ^ acc_resp_i.acc_resp.load_complete),
       .load_i    (1'b0),
-      .down_i    (acc_resp_i.load_complete),
+      .down_i    (acc_resp_i.acc_resp.load_complete),
       .d_i       ('0),
       .q_o       (acc_disp_loads_pending),
       .overflow_o(acc_disp_loads_overflow)
@@ -411,9 +411,9 @@ module acc_dispatcher
       .clk_i     (clk_i),
       .rst_ni    (rst_ni),
       .clear_i   (1'b0),
-      .en_i      (acc_st_disp ^ acc_resp_i.store_complete),
+      .en_i      (acc_st_disp ^ acc_resp_i.acc_resp.store_complete),
       .load_i    (1'b0),
-      .down_i    (acc_resp_i.store_complete),
+      .down_i    (acc_resp_i.acc_resp.store_complete),
       .d_i       ('0),
       .q_o       (acc_disp_stores_pending),
       .overflow_o(acc_disp_stores_overflow)

--- a/core/acc_dispatcher.sv
+++ b/core/acc_dispatcher.sv
@@ -36,6 +36,7 @@ module acc_dispatcher
     input logic [15:0][PLEN-3:0] pmpaddr_i,
     input logic [2:0] fcsr_frm_i,
     output logic dirty_v_state_o,
+    input logic acc_mmu_en_i,
     // Interface with the issue stage
     input scoreboard_entry_t issue_instr_i,
     input logic issue_instr_hs_i,
@@ -55,6 +56,9 @@ module acc_dispatcher
     output logic acc_stall_st_pending_o,
     input logic acc_no_st_pending_i,
     input dcache_req_i_t [2:0] dcache_req_ports_i,
+    // Interface with the MMU
+    output acc_pkg::acc_mmu_req_t acc_mmu_req_o,
+    input acc_pkg::acc_mmu_resp_t acc_mmu_resp_i,
     // Interface with the controller
     output logic ctrl_halt_o,
     input logic flush_unissued_instr_i,
@@ -219,6 +223,10 @@ module acc_dispatcher
   assign acc_req_o.acc_cons_en   = acc_cons_en_i;
   assign acc_req_o.inval_ready   = inval_ready_i;
 
+  // MMU interface
+  assign acc_req_o.acc_mmu_resp = acc_mmu_resp_i;
+  assign acc_req_o.acc_mmu_en   = acc_mmu_en_i;
+
   always_comb begin : accelerator_req_dispatcher
     // Do not fetch from the instruction queue
     acc_insn_queue_pop = 1'b0;
@@ -268,6 +276,9 @@ module acc_dispatcher
   assign acc_exception_o    = acc_resp_i.exception;
   assign acc_fflags_valid_o = acc_resp_i.fflags_valid;
   assign acc_fflags_o       = acc_resp_i.fflags;
+
+  // MMU interface
+  assign acc_mmu_req_o = acc_resp_i.acc_mmu_req;
 
   // Always ready to receive responses
   assign acc_req_o.resp_ready = 1'b1;

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -372,6 +372,11 @@ module cva6
   // ACCEL Commit
   logic acc_valid_acc_ex;
   // --------------
+  // EX <-> ACC_DISP
+  // --------------
+  acc_pkg::acc_mmu_req_t acc_mmu_req;
+  acc_pkg::acc_mmu_resp_t acc_mmu_resp;
+  // --------------
   // ID <-> COMMIT
   // --------------
   scoreboard_entry_t [CVA6ExtendCfg.NrCommitPorts-1:0] commit_instr_id_commit;
@@ -823,6 +828,9 @@ module cva6
       .cvxif_resp_i            (cvxif_resp),
       // Accelerator
       .acc_valid_i             (acc_valid_acc_ex),
+      // Accelerator MMU access
+      .acc_mmu_req_i           (acc_mmu_req),
+      .acc_mmu_resp_o          (acc_mmu_resp),
       // Performance counters
       .itlb_miss_o             (itlb_miss_ex_perf),
       .dtlb_miss_o             (dtlb_miss_ex_perf),
@@ -1298,6 +1306,7 @@ module cva6
         .pmpcfg_i              (pmpcfg),
         .pmpaddr_i             (pmpaddr),
         .fcsr_frm_i            (frm_csr_id_issue_ex),
+        .acc_mmu_en_i          (enable_translation_csr_ex),
         .dirty_v_state_o       (dirty_v_state),
         .issue_instr_i         (issue_instr_id_acc),
         .issue_instr_hs_i      (issue_instr_hs_id_acc),
@@ -1314,6 +1323,8 @@ module cva6
         .acc_stall_st_pending_o(stall_st_pending_ex),
         .acc_no_st_pending_i   (no_st_pending_commit),
         .dcache_req_ports_i    (dcache_req_ports_ex_cache),
+        .acc_mmu_req_o         (acc_mmu_req),
+        .acc_mmu_resp_i        (acc_mmu_resp),
         .ctrl_halt_o           (halt_acc_ctrl),
         .acc_dcache_req_ports_o(dcache_req_ports_acc_cache),
         .acc_dcache_req_ports_i(dcache_req_ports_cache_acc),
@@ -1340,6 +1351,9 @@ module cva6
 
     // D$ connection is unused
     assign dcache_req_ports_acc_cache = '0;
+
+    // MMU access is unused
+    assign acc_mmu_req                = '0;
 
     // No invalidation interface
     assign inval_valid                = '0;

--- a/core/ex_stage.sv
+++ b/core/ex_stage.sv
@@ -143,6 +143,9 @@ module ex_stage
     input  cvxif_pkg::cvxif_resp_t                                      cvxif_resp_i,
     // accelerate port result is valid - ACC_DISPATCHER
     input  logic                                                        acc_valid_i,
+    // Accelerator MMU access
+    input  acc_pkg::acc_mmu_req_t                                       acc_mmu_req_i,
+    output acc_pkg::acc_mmu_resp_t                                      acc_mmu_resp_o,
     // Enable virtual memory translation - CSR_REGFILE
     input  logic                                                        enable_translation_i,
     // TO_BE_COMPLETED - CSR_REGFILE
@@ -423,6 +426,8 @@ module ex_stage
       .enable_g_translation_i,
       .en_ld_st_translation_i,
       .en_ld_st_g_translation_i,
+      .acc_mmu_req_i,
+      .acc_mmu_resp_o,
       .icache_areq_i,
       .icache_areq_o,
       .priv_lvl_i,

--- a/core/include/acc_pkg.sv
+++ b/core/include/acc_pkg.sv
@@ -10,7 +10,27 @@
 package acc_pkg;
 
   // ----------------------
-  // Accelerator Interface
+  // Accelerator MMU Interface
+  // ----------------------
+
+  // Accelerator MMU interface
+  typedef struct packed {
+    logic                   acc_mmu_misaligned_ex;
+    logic                   acc_mmu_req;
+    logic [riscv::VLEN-1:0] acc_mmu_vaddr;
+    logic                   acc_mmu_is_store;
+  } acc_mmu_req_t;
+
+  typedef struct packed {
+    logic                   acc_mmu_dtlb_hit;
+    logic [riscv::PPNW-1:0] acc_mmu_dtlb_ppn;
+    logic                   acc_mmu_valid;
+    logic [riscv::PLEN-1:0] acc_mmu_paddr;
+    ariane_pkg::exception_t acc_mmu_exception;
+  } acc_mmu_resp_t;
+
+  // ----------------------
+  // Accelerator instruction/memory
   // ----------------------
 
   typedef struct packed {
@@ -44,5 +64,24 @@ package acc_pkg;
     logic                                 inval_valid;
     logic [63:0]                          inval_addr;
   } accelerator_resp_t;
+
+  // ----------------------
+  // Accelerator Interface
+  // ----------------------
+
+  typedef struct packed {
+    // Insn/mem
+    accelerator_req_t                     acc_req;
+    // MMU
+    logic                                 acc_mmu_en;
+    acc_mmu_resp_t                        acc_mmu_resp;
+  } cva6_to_acc_t;
+
+  typedef struct packed {
+    // Insn/mem
+    accelerator_resp_t                    acc_resp;
+    // MMU
+    acc_mmu_req_t                         acc_mmu_req;
+  } acc_to_cva6_t;
 
 endpackage

--- a/core/include/acc_pkg.sv
+++ b/core/include/acc_pkg.sv
@@ -32,7 +32,8 @@ package acc_pkg;
     logic                                 resp_valid;
     riscv::xlen_t                         result;
     logic [ariane_pkg::TRANS_ID_BITS-1:0] trans_id;
-    logic                                 error;
+    ariane_pkg::exception_t               exception;
+
     // Metadata
     logic                                 store_pending;
     logic                                 store_complete;

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -73,6 +73,10 @@ module load_store_unit
     input logic en_ld_st_translation_i,
     input logic en_ld_st_g_translation_i, // enable G-stage translation for load/stores
 
+    // Accelerator request for CVA6's MMU
+    input  acc_pkg::acc_mmu_req_t acc_mmu_req_i,
+    output acc_pkg::acc_mmu_resp_t acc_mmu_resp_o,
+
     // Instruction cache input request - CACHES
     input  icache_arsp_t icache_areq_i,
     // Instruction cache output request - CACHES
@@ -202,6 +206,14 @@ module load_store_unit
 
   logic                             hs_ld_st_inst;
   logic                             hlvx_inst;
+
+  // Accelerator's request for the MMU
+  assign acc_mmu_resp_o.acc_mmu_dtlb_hit_o  = '0;
+  assign acc_mmu_resp_o.acc_mmu_dtlb_ppn_o  = '0;
+  assign acc_mmu_resp_o.acc_mmu_valid_o     = '0;
+  assign acc_mmu_resp_o.acc_mmu_paddr_o     = '0;
+  assign acc_mmu_resp_o.acc_mmu_exception_o = '0;
+
   // -------------------
   // MMU e.g.: TLBs/PTW
   // -------------------
@@ -684,4 +696,3 @@ module load_store_unit
   assign rvfi_lsu_ctrl_o = lsu_ctrl;
 
 endmodule
-

--- a/core/load_store_unit.sv
+++ b/core/load_store_unit.sv
@@ -147,7 +147,7 @@ module load_store_unit
   // --------------------------------------
   // those are the signals which are always correct
   // e.g.: they keep the value in the stall case
-  lsu_ctrl_t                      lsu_ctrl;
+  lsu_ctrl_t                      lsu_ctrl, lsu_ctrl_byp;
 
   logic                           pop_st;
   logic                           pop_ld;
@@ -170,7 +170,7 @@ module load_store_unit
   logic                   st_valid_i;
   logic                   ld_valid_i;
   logic                   ld_translation_req;
-  logic                   st_translation_req;
+  logic                   cva6_st_translation_req, acc_st_translation_req, st_translation_req;
   logic [riscv::VLEN-1:0] ld_vaddr;
   logic [riscv::XLEN-1:0] ld_tinst;
   logic                   ld_hs_ld_st_inst;
@@ -179,16 +179,16 @@ module load_store_unit
   logic [riscv::XLEN-1:0] st_tinst;
   logic                   st_hs_ld_st_inst;
   logic                   st_hlvx_inst;
-  logic                   translation_req;
-  logic                   translation_valid;
-  logic [riscv::VLEN-1:0] mmu_vaddr;
-  logic [riscv::PLEN-1:0] mmu_paddr, mmu_vaddr_plen, fetch_vaddr_plen;
+  logic                   cva6_translation_req, acc_translation_req, translation_req;
+  logic                   cva6_translation_valid, acc_translataion_valid, translation_valid;
+  logic [riscv::VLEN-1:0] cva6_mmu_vaddr, acc_mmu_vaddr, mmu_vaddr;
+  logic [riscv::PLEN-1:0] cva6_mmu_paddr, acc_mmu_paddr, mmu_paddr, mmu_vaddr_plen, fetch_vaddr_plen;
   logic         [  riscv::XLEN-1:0] mmu_tinst;
   logic                             mmu_hs_ld_st_inst;
   logic                             mmu_hlvx_inst;
-  exception_t                       mmu_exception;
-  logic                             dtlb_hit;
-  logic         [  riscv::PPNW-1:0] dtlb_ppn;
+  exception_t                       cva6_mmu_exception, acc_mmu_exception, mmu_exception;
+  logic                             cva6_dtlb_hit, acc_dtlb_hit, dtlb_hit;
+  logic [riscv::PPNW-1:0]           cva6_dtlb_ppn, acc_dtlb_ppn, dtlb_ppn;
 
   logic                             ld_valid;
   logic         [TRANS_ID_BITS-1:0] ld_trans_id;
@@ -200,19 +200,12 @@ module load_store_unit
   logic         [             11:0] page_offset;
   logic                             page_offset_matches;
 
-  exception_t                       misaligned_exception;
+  exception_t                       cva6_misaligned_exception, acc_misaligned_exception, misaligned_exception;
   exception_t                       ld_ex;
   exception_t                       st_ex;
 
   logic                             hs_ld_st_inst;
   logic                             hlvx_inst;
-
-  // Accelerator's request for the MMU
-  assign acc_mmu_resp_o.acc_mmu_dtlb_hit_o  = '0;
-  assign acc_mmu_resp_o.acc_mmu_dtlb_ppn_o  = '0;
-  assign acc_mmu_resp_o.acc_mmu_valid_o     = '0;
-  assign acc_mmu_resp_o.acc_mmu_paddr_o     = '0;
-  assign acc_mmu_resp_o.acc_mmu_exception_o = '0;
 
   // -------------------
   // MMU e.g.: TLBs/PTW
@@ -314,10 +307,10 @@ module load_store_unit
   end else begin : gen_no_mmu
 
     if (riscv::VLEN > riscv::PLEN) begin
-      assign mmu_vaddr_plen   = mmu_vaddr[riscv::PLEN-1:0];
+      assign mmu_vaddr_plen   = cva6_mmu_vaddr[riscv::PLEN-1:0];
       assign fetch_vaddr_plen = icache_areq_i.fetch_vaddr[riscv::PLEN-1:0];
     end else begin
-      assign mmu_vaddr_plen   = {{{riscv::PLEN - riscv::VLEN} {1'b0}}, mmu_vaddr};
+      assign mmu_vaddr_plen   = {{{riscv::PLEN - riscv::VLEN} {1'b0}}, cva6_mmu_vaddr};
       assign fetch_vaddr_plen = {{{riscv::PLEN - riscv::VLEN} {1'b0}}, icache_areq_i.fetch_vaddr};
     end
 
@@ -337,22 +330,120 @@ module load_store_unit
 
     assign itlb_miss_o                         = 1'b0;
     assign dtlb_miss_o                         = 1'b0;
-    assign dtlb_ppn                            = mmu_vaddr_plen[riscv::PLEN-1:12];
-    assign dtlb_hit                            = 1'b1;
+    assign cva6_dtlb_ppn                       = mmu_vaddr_plen[riscv::PLEN-1:12];
+    assign cva6_dtlb_hit                       = 1'b1;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (~rst_ni) begin
-        mmu_paddr         <= '0;
-        translation_valid <= '0;
-        mmu_exception     <= '0;
+        cva6_mmu_paddr     <= '0;
+        translation_valid  <= '0;
+        cva6_mmu_exception <= '0;
       end else begin
-        mmu_paddr         <= mmu_vaddr_plen;
-        translation_valid <= translation_req;
-        mmu_exception     <= misaligned_exception;
+        cva6_mmu_paddr     <= mmu_vaddr_plen;
+        translation_valid  <= translation_req;
+        cva6_mmu_exception <= misaligned_exception;
       end
     end
   end
 
+  if (CVA6Cfg.EnableAccelerator) begin
+    // The MMU can be connected to CVA6 or the ACCELERATOR
+    enum logic {CVA6, ACC} mmu_state_d, mmu_state_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (~rst_ni) begin
+        mmu_state_q <= CVA6;
+      end else begin
+        mmu_state_q <= mmu_state_d;
+      end
+    end
+
+    // Straightforward and slow-reactive MMU arbitration logic
+    // This logic can be optimized to reduce answer latency and contention
+    always_comb begin
+      // Maintain state
+      mmu_state_d = mmu_state_q;
+
+      // Serve CVA6 and gate the accelerator by default
+      // MMU input
+      misaligned_exception             = cva6_misaligned_exception;
+      st_translation_req               = cva6_st_translation_req;
+      translation_req                  = cva6_translation_req;
+      mmu_vaddr                        = cva6_mmu_vaddr;
+      // MMU output
+      cva6_translation_valid           = translation_valid;
+      cva6_mmu_paddr                   = mmu_paddr;
+      cva6_mmu_exception               = mmu_exception;
+      cva6_dtlb_hit                    = dtlb_hit;
+      cva6_dtlb_ppn                    = dtlb_ppn;
+      acc_mmu_resp_o.acc_mmu_valid     = '0;
+      acc_mmu_resp_o.acc_mmu_paddr     = '0;
+      acc_mmu_resp_o.acc_mmu_exception = '0;
+      acc_mmu_resp_o.acc_mmu_dtlb_hit  = '0;
+      acc_mmu_resp_o.acc_mmu_dtlb_ppn  = '0;
+
+      unique case (mmu_state_q)
+        CVA6: begin
+          // Only the accelerator is requesting, and the lsu bypass queue is empty.
+          if (acc_mmu_req_i.acc_mmu_req && !lsu_valid_i && lsu_ready_o) begin
+            // Lock the MMU to the accelerator.
+            // If the issue stage is firing a mem op in this cycle,
+            // the bypass queue will buffer it.
+            mmu_state_d = ACC;
+          end
+          // Make this a mealy FSM to cut some latency.
+          // It should be okay timing-wise since cva6's requests already
+          // depend on lsu_valid_i. Moreover, lsu_ready_o is sequentially
+          // generated by the bypass and, in this first implementation,
+          // the acc request already depends combinatorially upon acc_mmu_req_i.acc_mmu_req.
+        end
+        ACC: begin
+          // MMU input
+          misaligned_exception             = acc_mmu_req_i.acc_mmu_misaligned_ex;
+          st_translation_req               = acc_mmu_req_i.acc_mmu_is_store;
+          translation_req                  = acc_mmu_req_i.acc_mmu_req;
+          mmu_vaddr                        = acc_mmu_req_i.acc_mmu_vaddr;
+          // MMU output
+          acc_mmu_resp_o.acc_mmu_valid     = translation_valid;
+          acc_mmu_resp_o.acc_mmu_paddr     = mmu_paddr;
+          acc_mmu_resp_o.acc_mmu_exception = mmu_exception;
+          acc_mmu_resp_o.acc_mmu_dtlb_hit  = dtlb_hit;
+          acc_mmu_resp_o.acc_mmu_dtlb_ppn  = dtlb_ppn;
+          cva6_translation_valid           = '0;
+          cva6_mmu_paddr                   = '0;
+          cva6_mmu_exception               = '0;
+          cva6_dtlb_hit                    = '0;
+          cva6_dtlb_ppn                    = '0;
+          // Get back to CVA6 after the translation
+          if (translation_valid) mmu_state_d = CVA6;
+        end
+        default: mmu_state_d = CVA6;
+      endcase
+    end
+
+    always_comb begin
+      // Feed forward
+      lsu_ctrl = lsu_ctrl_byp;
+      // Mask the lsu valid so that cva6's req gets buffered in the
+      // bypass queue when the MMU is being used by the accelerator.
+      lsu_ctrl.valid = (mmu_state_q == ACC) ? 1'b0 : lsu_ctrl_byp.valid;
+    end
+  end else begin
+    // MMU input
+    assign misaligned_exception   = cva6_misaligned_exception;
+    assign st_translation_req     = cva6_st_translation_req;
+    assign translation_req        = cva6_translation_req;
+    assign mmu_vaddr              = cva6_mmu_vaddr;
+    // MMU output
+    assign cva6_translation_valid = translation_valid;
+    assign cva6_mmu_paddr         = mmu_paddr;
+    assign cva6_mmu_exception     = mmu_exception;
+    assign cva6_dtlb_hit          = dtlb_hit;
+    assign cva6_dtlb_ppn          = dtlb_ppn;
+    // No accelerator
+    assign acc_mmu_resp_o = '0;
+    // Feed forward the lsu_ctrl bypass
+    assign lsu_ctrl = lsu_ctrl_byp;
+  end
 
   logic store_buffer_empty;
   // ------------------
@@ -380,15 +471,15 @@ module load_store_unit
       .result_o             (st_result),
       .ex_o                 (st_ex),
       // MMU port
-      .translation_req_o    (st_translation_req),
+      .translation_req_o    (cva6_st_translation_req),
       .vaddr_o              (st_vaddr),
       .rvfi_mem_paddr_o     (rvfi_mem_paddr_o),
       .tinst_o              (st_tinst),
       .hs_ld_st_inst_o      (st_hs_ld_st_inst),
       .hlvx_inst_o          (st_hlvx_inst),
-      .paddr_i              (mmu_paddr),
-      .ex_i                 (mmu_exception),
-      .dtlb_hit_i           (dtlb_hit),
+      .paddr_i              (cva6_mmu_paddr),
+      .ex_i                 (cva6_mmu_exception),
+      .dtlb_hit_i           (cva6_dtlb_hit),
       // Load Unit
       .page_offset_i        (page_offset),
       .page_offset_matches_o(page_offset_matches),
@@ -420,10 +511,10 @@ module load_store_unit
       .tinst_o              (ld_tinst),
       .hs_ld_st_inst_o      (ld_hs_ld_st_inst),
       .hlvx_inst_o          (ld_hlvx_inst),
-      .paddr_i              (mmu_paddr),
-      .ex_i                 (mmu_exception),
-      .dtlb_hit_i           (dtlb_hit),
-      .dtlb_ppn_i           (dtlb_ppn),
+      .paddr_i              (cva6_mmu_paddr),
+      .ex_i                 (cva6_mmu_exception),
+      .dtlb_hit_i           (cva6_dtlb_hit),
+      .dtlb_ppn_i           (cva6_dtlb_ppn),
       // to store unit
       .page_offset_o        (page_offset),
       .page_offset_matches_i(page_offset_matches),
@@ -469,19 +560,19 @@ module load_store_unit
     ld_valid_i        = 1'b0;
     st_valid_i        = 1'b0;
 
-    translation_req   = 1'b0;
-    mmu_vaddr         = {riscv::VLEN{1'b0}};
-    mmu_tinst         = {riscv::XLEN{1'b0}};
-    mmu_hs_ld_st_inst = 1'b0;
-    mmu_hlvx_inst     = 1'b0;
+    cva6_translation_req = 1'b0;
+    cva6_mmu_vaddr       = {riscv::VLEN{1'b0}};
+    mmu_tinst            = {riscv::XLEN{1'b0}};
+    mmu_hs_ld_st_inst    = 1'b0;
+    mmu_hlvx_inst        = 1'b0;
 
     // check the operation to activate the right functional unit accordingly
     unique case (lsu_ctrl.fu)
       // all loads go here
       LOAD: begin
-        ld_valid_i      = lsu_ctrl.valid;
-        translation_req = ld_translation_req;
-        mmu_vaddr       = ld_vaddr;
+        ld_valid_i           = lsu_ctrl.valid;
+        cva6_translation_req = ld_translation_req;
+        cva6_mmu_vaddr       = ld_vaddr;
         if (CVA6Cfg.RVH) begin
           mmu_tinst         = ld_tinst;
           mmu_hs_ld_st_inst = ld_hs_ld_st_inst;
@@ -490,9 +581,9 @@ module load_store_unit
       end
       // all stores go here
       STORE: begin
-        st_valid_i      = lsu_ctrl.valid;
-        translation_req = st_translation_req;
-        mmu_vaddr       = st_vaddr;
+        st_valid_i           = lsu_ctrl.valid;
+        cva6_translation_req = st_translation_req;
+        cva6_mmu_vaddr       = st_vaddr;
         if (CVA6Cfg.RVH) begin
           mmu_tinst         = st_tinst;
           mmu_hs_ld_st_inst = st_hs_ld_st_inst;
@@ -550,7 +641,7 @@ module load_store_unit
   // the misaligned exception is passed to the functional unit via the MMU, which in case
   // can augment the exception if other memory related exceptions like a page fault or access errors
   always_comb begin : data_misaligned_detection
-    misaligned_exception = {
+    cva6_misaligned_exception = {
       {riscv::XLEN{1'b0}},
       {riscv::XLEN{1'b0}},
       {riscv::GPLEN{1'b0}},
@@ -596,65 +687,65 @@ module load_store_unit
     if (data_misaligned) begin
 
       if (lsu_ctrl.fu == LOAD) begin
-        misaligned_exception.cause = riscv::LD_ADDR_MISALIGNED;
-        misaligned_exception.valid = 1'b1;
+        cva6_misaligned_exception.cause = riscv::LD_ADDR_MISALIGNED;
+        cva6_misaligned_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
-        misaligned_exception.tval2 = '0;
-        misaligned_exception.tinst = lsu_ctrl.tinst;
-        misaligned_exception.gva   = ld_st_v_i;
+          cva6_misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
+        cva6_misaligned_exception.tval2 = '0;
+        cva6_misaligned_exception.tinst = lsu_ctrl.tinst;
+        cva6_misaligned_exception.gva   = ld_st_v_i;
 
       end else if (lsu_ctrl.fu == STORE) begin
-        misaligned_exception.cause = riscv::ST_ADDR_MISALIGNED;
-        misaligned_exception.valid = 1'b1;
+        cva6_misaligned_exception.cause = riscv::ST_ADDR_MISALIGNED;
+        cva6_misaligned_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
-        misaligned_exception.tval2 = '0;
-        misaligned_exception.tinst = lsu_ctrl.tinst;
-        misaligned_exception.gva   = ld_st_v_i;
+          cva6_misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
+        cva6_misaligned_exception.tval2 = '0;
+        cva6_misaligned_exception.tinst = lsu_ctrl.tinst;
+        cva6_misaligned_exception.gva   = ld_st_v_i;
       end
     end
 
     if (ariane_pkg::MMU_PRESENT && en_ld_st_translation_i && lsu_ctrl.overflow) begin
 
       if (lsu_ctrl.fu == LOAD) begin
-        misaligned_exception.cause = riscv::LD_ACCESS_FAULT;
-        misaligned_exception.valid = 1'b1;
+        cva6_misaligned_exception.cause = riscv::LD_ACCESS_FAULT;
+        cva6_misaligned_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
-        misaligned_exception.tval2 = '0;
-        misaligned_exception.tinst = lsu_ctrl.tinst;
-        misaligned_exception.gva   = ld_st_v_i;
+          cva6_misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
+        cva6_misaligned_exception.tval2 = '0;
+        cva6_misaligned_exception.tinst = lsu_ctrl.tinst;
+        cva6_misaligned_exception.gva   = ld_st_v_i;
 
       end else if (lsu_ctrl.fu == STORE) begin
-        misaligned_exception.cause = riscv::ST_ACCESS_FAULT;
-        misaligned_exception.valid = 1'b1;
+        cva6_misaligned_exception.cause = riscv::ST_ACCESS_FAULT;
+        cva6_misaligned_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
-        misaligned_exception.tval2 = '0;
-        misaligned_exception.tinst = lsu_ctrl.tinst;
-        misaligned_exception.gva   = ld_st_v_i;
+          cva6_misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
+        cva6_misaligned_exception.tval2 = '0;
+        cva6_misaligned_exception.tinst = lsu_ctrl.tinst;
+        cva6_misaligned_exception.gva   = ld_st_v_i;
       end
     end
 
     if (ariane_pkg::MMU_PRESENT && CVA6Cfg.RVH && en_ld_st_g_translation_i && !en_ld_st_translation_i && lsu_ctrl.g_overflow) begin
 
       if (lsu_ctrl.fu == LOAD) begin
-        misaligned_exception.cause = riscv::LOAD_GUEST_PAGE_FAULT;
-        misaligned_exception.valid = 1'b1;
+        cva6_misaligned_exception.cause = riscv::LOAD_GUEST_PAGE_FAULT;
+        cva6_misaligned_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
-        misaligned_exception.tval2 = '0;
-        misaligned_exception.tinst = lsu_ctrl.tinst;
-        misaligned_exception.gva   = ld_st_v_i;
+          cva6_misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
+        cva6_misaligned_exception.tval2 = '0;
+        cva6_misaligned_exception.tinst = lsu_ctrl.tinst;
+        cva6_misaligned_exception.gva   = ld_st_v_i;
       end else if (lsu_ctrl.fu == STORE) begin
-        misaligned_exception.cause = riscv::STORE_GUEST_PAGE_FAULT;
-        misaligned_exception.valid = 1'b1;
+        cva6_misaligned_exception.cause = riscv::STORE_GUEST_PAGE_FAULT;
+        cva6_misaligned_exception.valid = 1'b1;
         if (CVA6Cfg.TvalEn)
-          misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
-        misaligned_exception.tval2 = '0;
-        misaligned_exception.tinst = lsu_ctrl.tinst;
-        misaligned_exception.gva   = ld_st_v_i;
+          cva6_misaligned_exception.tval = {{riscv::XLEN - riscv::VLEN{1'b0}}, lsu_ctrl.vaddr};
+        cva6_misaligned_exception.tval2 = '0;
+        cva6_misaligned_exception.tinst = lsu_ctrl.tinst;
+        cva6_misaligned_exception.gva   = ld_st_v_i;
       end
     end
   end
@@ -688,7 +779,7 @@ module load_store_unit
       .pop_ld_i       (pop_ld),
       .pop_st_i       (pop_st),
 
-      .lsu_ctrl_o(lsu_ctrl),
+      .lsu_ctrl_o(lsu_ctrl_byp),
       .ready_o   (lsu_ready_o),
       .*
   );


### PR DESCRIPTION
### Solve bug in `acc_dispatcher`
Don't mark vector instructions as "non-speculative" when flushing in the same cycle. Indeed, instructions with side effects flush the unissued instructions from the controller. The accelerator dispatcher buffer is flushed when this happens and avoids accepting a new instruction, but it does not prevent the actual issue during a flush cycle.

### Solve non-propagated exception bug:
The exception from the vector accelerator is now correctly propagated to CVA6 backend for commit.

### Add MMU interface for accelerator:
CVA6 can now share its MMU with the vector accelerator with a simple FSM and multiplexer.

### Extend the instruction tracer to ease debugging:
Add initial support for VLD/VST to CVA6 tracer.

### Update signal labels:
Update the nomenclature of the CVA6-Ara interface signals.