### PR TITLE
Fix rs3 forwarding for cvxif operations

### DIFF
--- a/core/issue_read_operands.sv
+++ b/core/issue_read_operands.sv
@@ -185,6 +185,7 @@ module issue_read_operands
   logic [ CVA6Cfg.NrIssuePorts-1:0]                                rs3_raw_check;
   logic [ CVA6Cfg.NrIssuePorts-1:0]                                rs3_has_raw;
   logic [ CVA6Cfg.NrIssuePorts-1:0]                                rs3_fpr;
+  logic [ CVA6Cfg.NrIssuePorts-1:0]                                rs3_gpr_cvxif;
 
 
   logic [CVA6Cfg.NR_SB_ENTRIES-1:0][ariane_pkg::REG_ADDR_SIZE-1:0] rd_list;
@@ -428,6 +429,8 @@ module issue_read_operands
     assign rs1_fpr[i] = (CVA6Cfg.FpPresent && ariane_pkg::is_rs1_fpr(issue_instr_i[i].op));
     assign rs2_fpr[i] = (CVA6Cfg.FpPresent && ariane_pkg::is_rs2_fpr(issue_instr_i[i].op));
     assign rs3_fpr[i] = (CVA6Cfg.FpPresent && ariane_pkg::is_imm_fpr(issue_instr_i[i].op));
+    assign rs3_gpr_cvxif[i] = CVA6Cfg.CvxifEn && (OPERANDS_PER_INSTR == 3)
+        && issue_instr_i[i].op == OFFLOAD;
   end
 
   // ----------------------------------
@@ -485,7 +488,7 @@ module issue_read_operands
         .idx_o(idx_hzd_rs3[i]),
         .valid_o(rs3_raw_check[i])
     );
-    assign rs3_has_raw[i] = rs3_raw_check[i] && rs3_fpr[i];
+    assign rs3_has_raw[i] = rs3_raw_check[i] && (rs3_fpr[i] || rs3_gpr_cvxif[i]);
   end
 
   // ----------------------------------
@@ -536,7 +539,7 @@ module issue_read_operands
     // operand forwarding signals
     forward_rs1 = '0;
     forward_rs2 = '0;
-    forward_rs3 = '0;  // FPR only
+    forward_rs3 = '0;  // FPR and CV-X-IF only
 
     for (int unsigned i = 0; i < CVA6Cfg.NrIssuePorts; i++) begin
       if (rs1_has_raw[i]) begin
@@ -557,7 +560,7 @@ module issue_read_operands
         end
       end
 
-      if (rs3_has_raw[i] && rs3_fpr[i]) begin
+      if (rs3_has_raw[i]) begin
         if (rs3_valid[i]) begin
           forward_rs3[i] = 1'b1;
         end else begin  // the operand is not available -> stall
@@ -844,7 +847,7 @@ module issue_read_operands
   logic [CVA6Cfg.NrCommitPorts-1:0][CVA6Cfg.XLEN-1:0] wdata_pack;
   logic [CVA6Cfg.NrCommitPorts-1:0]                   we_pack;
 
-  //adjust address to read from register file (when synchronous RAM is used reads take one cycle, so we advance the address)   
+  //adjust address to read from register file (when synchronous RAM is used reads take one cycle, so we advance the address)
   for (genvar i = 0; i <= CVA6Cfg.NrIssuePorts - 1; i++) begin
     assign raddr_pack[i*OPERANDS_PER_INSTR+0] = CVA6Cfg.FpgaEn && CVA6Cfg.FpgaAlteraEn ? issue_instr_i_prev[i].rs1[4:0] : issue_instr_i[i].rs1[4:0];
     assign raddr_pack[i*OPERANDS_PER_INSTR+1] = CVA6Cfg.FpgaEn && CVA6Cfg.FpgaAlteraEn ? issue_instr_i_prev[i].rs2[4:0] : issue_instr_i[i].rs2[4:0];


### PR DESCRIPTION
Hello everyone, 

This PR has the aim to enable the forwarding of `rs3` source register for instructions offloaded through the OpenHW `CV-X-IF`.
As it was, `rs3` forwarding was performed only for FP operations.

The fix follows the implementation of [cva6-openhw-rs3raw](https://github.com/openhwgroup/cva6/commit/17e5cc954e94ff7ba6a211dbe1fc939f37f96052).